### PR TITLE
fix(auth): pass through Mech Storage infrastructure HTTP statuses

### DIFF
--- a/src/auth/__tests__/infrastructure-error-handler.test.ts
+++ b/src/auth/__tests__/infrastructure-error-handler.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { ClearAuthRateLimitError } from "../../errors.js"
+import type { ClearAuthConfig } from "../../types.js"
+import type { Kysely } from "kysely"
+import type { Database } from "../../database/schema.js"
+
+const { mockLoginUser } = vi.hoisted(() => ({
+  mockLoginUser: vi.fn(),
+}))
+
+vi.mock("../login.js", () => ({
+  loginUser: mockLoginUser,
+  toPublicLoginResult: vi.fn(),
+}))
+
+import { handleAuthRequest } from "../handler.js"
+
+describe("handleAuthRequest infrastructure errors", () => {
+  const config: ClearAuthConfig = {
+    database: {} as Kysely<Database>,
+    secret: "test-secret",
+    baseUrl: "http://localhost:3000",
+  }
+
+  beforeEach(() => {
+    mockLoginUser.mockReset()
+  })
+
+  it("returns 429 when login hits Mech Storage rate limit", async () => {
+    mockLoginUser.mockRejectedValue(
+      new ClearAuthRateLimitError(30_000, { statusCode: 429 })
+    )
+
+    const response = await handleAuthRequest(
+      new Request("http://localhost:3000/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "u@example.com", password: "SecurePass123!" }),
+      }),
+      config
+    )
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get("Retry-After")).toBe("30")
+    const body = await response.json()
+    expect(body.code).toBe("RATE_LIMITED")
+  })
+})

--- a/src/auth/__tests__/infrastructure-error-handler.test.ts
+++ b/src/auth/__tests__/infrastructure-error-handler.test.ts
@@ -27,9 +27,7 @@ describe("handleAuthRequest infrastructure errors", () => {
   })
 
   it("returns 429 when login hits Mech Storage rate limit", async () => {
-    mockLoginUser.mockRejectedValue(
-      new ClearAuthRateLimitError(30_000, { statusCode: 429 })
-    )
+    mockLoginUser.mockRejectedValue(new ClearAuthRateLimitError(30_000))
 
     const response = await handleAuthRequest(
       new Request("http://localhost:3000/auth/login", {

--- a/src/auth/__tests__/infrastructure-error-handler.test.ts
+++ b/src/auth/__tests__/infrastructure-error-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { ClearAuthRateLimitError } from "../../errors.js"
+import { ClearAuthNetworkError, ClearAuthRateLimitError } from "../../errors.js"
 import type { ClearAuthConfig } from "../../types.js"
 import type { Kysely } from "kysely"
 import type { Database } from "../../database/schema.js"
@@ -44,5 +44,22 @@ describe("handleAuthRequest infrastructure errors", () => {
     expect(response.headers.get("Retry-After")).toBe("30")
     const body = await response.json()
     expect(body.code).toBe("RATE_LIMITED")
+  })
+
+  it("returns 502 when login hits upstream gateway error", async () => {
+    mockLoginUser.mockRejectedValue(new ClearAuthNetworkError("upstream", 502))
+
+    const response = await handleAuthRequest(
+      new Request("http://localhost:3000/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "u@example.com", password: "SecurePass123!" }),
+      }),
+      config
+    )
+
+    expect(response.status).toBe(502)
+    const body = await response.json()
+    expect(body.code).toBe("SERVICE_UNAVAILABLE")
   })
 })

--- a/src/auth/handler.ts
+++ b/src/auth/handler.ts
@@ -137,11 +137,6 @@ function errorResponse(error: any): Response {
 
   const infrastructure = infrastructureErrorResponse(error, 'auth')
   if (infrastructure) {
-    if (infrastructure.status >= 500) {
-      console.error('Infrastructure error:', error)
-    } else {
-      console.warn('Infrastructure error:', error)
-    }
     return infrastructure
   }
 

--- a/src/auth/handler.ts
+++ b/src/auth/handler.ts
@@ -24,6 +24,7 @@ import {
   createCookieHeader,
 } from '../oauth/callbacks.js'
 import { AuthError, isValidReturnTo } from './utils.js'
+import { infrastructureErrorResponse } from '../utils/infrastructure-error-response.js'
 import { toPublicUser } from '../database/schema.js'
 import { EmailManager } from '../email/manager.js'
 import { issueTokenPair } from '../jwt/issue-token-pair.js'
@@ -134,7 +135,16 @@ function errorResponse(error: any): Response {
     )
   }
 
-  // Unknown error
+  const infrastructure = infrastructureErrorResponse(error, 'auth')
+  if (infrastructure) {
+    if (infrastructure.status >= 500) {
+      console.error('Infrastructure error:', error)
+    } else {
+      console.warn('Infrastructure error:', error)
+    }
+    return infrastructure
+  }
+
   console.error('Unexpected error:', error)
   return jsonResponse(
     {

--- a/src/device-auth/__tests__/infrastructure-error-handler.test.ts
+++ b/src/device-auth/__tests__/infrastructure-error-handler.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { ClearAuthNetworkError } from "../../errors.js"
+import type { ClearAuthConfig } from "../../types.js"
+import type { Kysely } from "kysely"
+import type { Database } from "../../database/schema.js"
+
+const { mockListUserDevices, mockGetSessionFromCookie } = vi.hoisted(() => ({
+  mockListUserDevices: vi.fn(),
+  mockGetSessionFromCookie: vi.fn(),
+}))
+
+vi.mock("../device-registration.js", () => ({
+  listUserDevices: mockListUserDevices,
+  revokeDevice: vi.fn(),
+}))
+
+vi.mock("../../session/validate.js", () => ({
+  getSessionFromCookie: mockGetSessionFromCookie,
+}))
+
+import { handleListDevicesRequest } from "../handlers.js"
+
+describe("handleListDevicesRequest infrastructure errors", () => {
+  const config: ClearAuthConfig = {
+    database: {} as Kysely<Database>,
+    secret: "test-secret",
+    baseUrl: "http://localhost:3000",
+  }
+
+  beforeEach(() => {
+    mockListUserDevices.mockReset()
+    mockGetSessionFromCookie.mockReset()
+    mockGetSessionFromCookie.mockResolvedValue({
+      user: { id: "user-1", email: "u@example.com" },
+      session: { id: "sess-1" },
+    })
+  })
+
+  it("returns 504 when listing devices hits upstream timeout class error", async () => {
+    mockListUserDevices.mockRejectedValue(new ClearAuthNetworkError("upstream", 504))
+
+    const response = await handleListDevicesRequest(
+      new Request("http://localhost:3000/auth/devices", { method: "GET" }),
+      config
+    )
+
+    expect(response.status).toBe(504)
+    const body = await response.json()
+    expect(body.error).toBe("temporarily_unavailable")
+  })
+})

--- a/src/device-auth/handlers.ts
+++ b/src/device-auth/handlers.ts
@@ -19,6 +19,7 @@ import { verifyIntegrityToken } from './android-verifier.js'
 import { listUserDevices, revokeDevice } from './device-registration.js'
 import type { ChallengeResponse, DeviceRegistrationRequest, DeviceRegistrationResponse } from './types.js'
 import { isDevicePlatform, isKeyAlgorithm } from './types.js'
+import { infrastructureErrorResponse } from '../utils/infrastructure-error-response.js'
 
 /**
  * Error response
@@ -427,6 +428,10 @@ export async function handleDeviceRegisterRequest(
       headers: { 'Content-Type': 'application/json' },
     })
   } catch (error) {
+    const infrastructure = infrastructureErrorResponse(error, 'oauth')
+    if (infrastructure) {
+      return infrastructure
+    }
     console.error('Device registration failed:', error)
     return new Response(
       JSON.stringify({
@@ -469,6 +474,10 @@ export async function handleChallengeRequest(
       headers: { 'Content-Type': 'application/json' },
     })
   } catch (error) {
+    const infrastructure = infrastructureErrorResponse(error, 'oauth')
+    if (infrastructure) {
+      return infrastructure
+    }
     console.error('Challenge generation failed:', error)
     return new Response(
       JSON.stringify({
@@ -534,6 +543,10 @@ export async function handleListDevicesRequest(
       headers: { 'Content-Type': 'application/json' },
     })
   } catch (error) {
+    const infrastructure = infrastructureErrorResponse(error, 'oauth')
+    if (infrastructure) {
+      return infrastructure
+    }
     console.error('List devices failed:', error)
     return new Response(
       JSON.stringify({
@@ -605,6 +618,10 @@ export async function handleRevokeDeviceRequest(
       }
     )
   } catch (error) {
+    const infrastructure = infrastructureErrorResponse(error, 'oauth')
+    if (infrastructure) {
+      return infrastructure
+    }
     console.error('Revoke device failed:', error)
     return new Response(
       JSON.stringify({

--- a/src/jwt/__tests__/infrastructure-error-handler.test.ts
+++ b/src/jwt/__tests__/infrastructure-error-handler.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { generateKeyPair, exportPKCS8, exportSPKI } from "jose"
+import { ClearAuthNetworkError } from "../../errors.js"
+import type { JwtConfig } from "../types.js"
+import type { Kysely } from "kysely"
+import type { Database } from "../../database/schema.js"
+
+const { mockCreateRefreshToken } = vi.hoisted(() => ({
+  mockCreateRefreshToken: vi.fn(),
+}))
+
+vi.mock("../refresh-tokens.js", () => ({
+  createRefreshToken: mockCreateRefreshToken,
+  getRefreshToken: vi.fn(),
+  rotateRefreshToken: vi.fn(),
+  revokeRefreshToken: vi.fn(),
+  updateLastUsed: vi.fn(),
+}))
+
+import { handleTokenRequest } from "../handlers.js"
+
+describe("handleTokenRequest infrastructure errors", () => {
+  const db = {} as Kysely<Database>
+  let jwtConfig: JwtConfig
+
+  beforeEach(async () => {
+    mockCreateRefreshToken.mockReset()
+    const { privateKey, publicKey } = await generateKeyPair("ES256", { extractable: true })
+    jwtConfig = {
+      privateKey: await exportPKCS8(privateKey),
+      publicKey: await exportSPKI(publicKey),
+      algorithm: "ES256",
+    }
+  })
+
+  it("returns 503 when refresh token persistence hits upstream outage", async () => {
+    mockCreateRefreshToken.mockRejectedValue(new ClearAuthNetworkError("upstream", 503))
+
+    const response = await handleTokenRequest(
+      new Request("http://localhost:3000/auth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: "user-1", email: "u@example.com" }),
+      }),
+      db,
+      jwtConfig
+    )
+
+    expect(response.status).toBe(503)
+    const body = await response.json()
+    expect(body.error).toBe("temporarily_unavailable")
+  })
+})

--- a/src/jwt/handlers.ts
+++ b/src/jwt/handlers.ts
@@ -230,6 +230,7 @@ export async function handleTokenRequest(
     if (infrastructure) {
       return infrastructure
     }
+    console.error('Unexpected error:', error)
     return new Response(
       JSON.stringify({
         error: 'server_error',
@@ -392,6 +393,7 @@ export async function handleRefreshRequest(
     if (infrastructure) {
       return infrastructure
     }
+    console.error('Unexpected error:', error)
     return new Response(
       JSON.stringify({
         error: 'server_error',
@@ -487,6 +489,7 @@ export async function handleRevokeRequest(
     if (infrastructure) {
       return infrastructure
     }
+    console.error('Unexpected error:', error)
     return new Response(
       JSON.stringify({
         error: 'server_error',

--- a/src/jwt/handlers.ts
+++ b/src/jwt/handlers.ts
@@ -233,7 +233,7 @@ export async function handleTokenRequest(
     return new Response(
       JSON.stringify({
         error: 'server_error',
-        message: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Internal server error',
       } satisfies ErrorResponse),
       {
         status: 500,
@@ -395,7 +395,7 @@ export async function handleRefreshRequest(
     return new Response(
       JSON.stringify({
         error: 'server_error',
-        message: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Internal server error',
       } satisfies ErrorResponse),
       {
         status: 500,
@@ -490,7 +490,7 @@ export async function handleRevokeRequest(
     return new Response(
       JSON.stringify({
         error: 'server_error',
-        message: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Internal server error',
       } satisfies ErrorResponse),
       {
         status: 500,

--- a/src/jwt/handlers.ts
+++ b/src/jwt/handlers.ts
@@ -21,6 +21,7 @@ import {
   revokeRefreshToken,
   updateLastUsed,
 } from './refresh-tokens.js'
+import { infrastructureErrorResponse } from '../utils/infrastructure-error-response.js'
 
 /**
  * Parse JSON body from request
@@ -225,6 +226,10 @@ export async function handleTokenRequest(
       headers: { 'Content-Type': 'application/json' },
     })
   } catch (error) {
+    const infrastructure = infrastructureErrorResponse(error, 'oauth')
+    if (infrastructure) {
+      return infrastructure
+    }
     return new Response(
       JSON.stringify({
         error: 'server_error',
@@ -383,6 +388,10 @@ export async function handleRefreshRequest(
       headers: { 'Content-Type': 'application/json' },
     })
   } catch (error) {
+    const infrastructure = infrastructureErrorResponse(error, 'oauth')
+    if (infrastructure) {
+      return infrastructure
+    }
     return new Response(
       JSON.stringify({
         error: 'server_error',
@@ -474,6 +483,10 @@ export async function handleRevokeRequest(
       }
     )
   } catch (error) {
+    const infrastructure = infrastructureErrorResponse(error, 'oauth')
+    if (infrastructure) {
+      return infrastructure
+    }
     return new Response(
       JSON.stringify({
         error: 'server_error',

--- a/src/oauth/__tests__/infrastructure-error-handler.test.ts
+++ b/src/oauth/__tests__/infrastructure-error-handler.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { ClearAuthRateLimitError } from "../../errors.js"
+import type { ClearAuthConfig } from "../../types.js"
+import type { Kysely } from "kysely"
+import type { Database } from "../../database/schema.js"
+
+const { mockGenerateGitHubAuthUrl } = vi.hoisted(() => ({
+  mockGenerateGitHubAuthUrl: vi.fn(),
+}))
+
+vi.mock("../github.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../github.js")>()
+  return {
+    ...actual,
+    generateGitHubAuthUrl: mockGenerateGitHubAuthUrl,
+  }
+})
+
+import { handleOAuthRequest } from "../handler.js"
+
+describe("handleOAuthRequest infrastructure errors", () => {
+  const config: ClearAuthConfig = {
+    database: {} as Kysely<Database>,
+    secret: "test-secret",
+    baseUrl: "http://localhost:3000",
+    oauth: {
+      github: {
+        clientId: "id",
+        clientSecret: "secret",
+        redirectUri: "http://localhost:3000/auth/callback/github",
+      },
+    },
+  }
+
+  beforeEach(() => {
+    mockGenerateGitHubAuthUrl.mockReset()
+  })
+
+  it("returns 429 when OAuth login initiation hits Mech Storage rate limit", async () => {
+    mockGenerateGitHubAuthUrl.mockRejectedValue(new ClearAuthRateLimitError(12_000))
+
+    const response = await handleOAuthRequest(
+      new Request("http://localhost:3000/auth/oauth/github"),
+      config
+    )
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get("Retry-After")).toBe("12")
+    const body = await response.json()
+    expect(body.error).toBe("temporarily_unavailable")
+  })
+})

--- a/src/oauth/__tests__/infrastructure-error-handler.test.ts
+++ b/src/oauth/__tests__/infrastructure-error-handler.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { ClearAuthRateLimitError } from "../../errors.js"
+import { ClearAuthNetworkError, ClearAuthRateLimitError } from "../../errors.js"
 import type { ClearAuthConfig } from "../../types.js"
 import type { Kysely } from "kysely"
 import type { Database } from "../../database/schema.js"
 
-const { mockGenerateGitHubAuthUrl } = vi.hoisted(() => ({
+const { mockGenerateGitHubAuthUrl, mockHandleGitHubCallback, mockUpsertOAuthUser } = vi.hoisted(() => ({
   mockGenerateGitHubAuthUrl: vi.fn(),
+  mockHandleGitHubCallback: vi.fn(),
+  mockUpsertOAuthUser: vi.fn(),
 }))
 
 vi.mock("../github.js", async (importOriginal) => {
@@ -13,6 +15,15 @@ vi.mock("../github.js", async (importOriginal) => {
   return {
     ...actual,
     generateGitHubAuthUrl: mockGenerateGitHubAuthUrl,
+    handleGitHubCallback: mockHandleGitHubCallback,
+  }
+})
+
+vi.mock("../callbacks.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../callbacks.js")>()
+  return {
+    ...actual,
+    upsertOAuthUser: mockUpsertOAuthUser,
   }
 })
 
@@ -34,6 +45,8 @@ describe("handleOAuthRequest infrastructure errors", () => {
 
   beforeEach(() => {
     mockGenerateGitHubAuthUrl.mockReset()
+    mockHandleGitHubCallback.mockReset()
+    mockUpsertOAuthUser.mockReset()
   })
 
   it("returns 429 when OAuth login initiation hits Mech Storage rate limit", async () => {
@@ -46,6 +59,25 @@ describe("handleOAuthRequest infrastructure errors", () => {
 
     expect(response.status).toBe(429)
     expect(response.headers.get("Retry-After")).toBe("12")
+    const body = await response.json()
+    expect(body.error).toBe("temporarily_unavailable")
+  })
+
+  it("returns 503 when OAuth callback persistence hits upstream outage", async () => {
+    mockHandleGitHubCallback.mockResolvedValue({
+      profile: { id: "gh-1", email: "u@example.com", name: "User" },
+    })
+    mockUpsertOAuthUser.mockRejectedValue(new ClearAuthNetworkError("upstream", 503))
+
+    const response = await handleOAuthRequest(
+      new Request(
+        "http://localhost:3000/auth/callback/github?code=abc&state=state-1",
+        { headers: { Cookie: "oauth_state=state-1" } }
+      ),
+      config
+    )
+
+    expect(response.status).toBe(503)
     const body = await response.json()
     expect(body.error).toBe("temporarily_unavailable")
   })

--- a/src/oauth/handler.ts
+++ b/src/oauth/handler.ts
@@ -15,6 +15,7 @@ import { generateMicrosoftAuthUrl, handleMicrosoftCallback } from './microsoft.j
 import { generateLinkedInAuthUrl, handleLinkedInCallback } from './linkedin.js'
 import { generateMetaAuthUrl, handleMetaCallback } from './meta.js'
 import { normalizeAuthPath } from '../utils/normalize-auth-path.js'
+import { infrastructureErrorResponse } from '../utils/infrastructure-error-response.js'
 import {
   upsertOAuthUser,
   createSession,
@@ -81,6 +82,10 @@ async function handleOAuthLogin(
     const headers = createHeadersWithCookies(cookies, url.toString())
     return new Response(null, { status: 302, headers })
   } catch (error) {
+    const infrastructure = infrastructureErrorResponse(error, 'oauth')
+    if (infrastructure) {
+      return infrastructure
+    }
     console.error(providerName + ' login error:', error) // nosemgrep
     return new Response('OAuth configuration error', { status: 500 })
   }
@@ -166,6 +171,10 @@ async function handleOAuthCallbackRequest(
     const headers = createHeadersWithCookies([sessionCookie, ...additionalCookies, ...deleteCookies], '/')
     return new Response(null, { status: 302, headers })
   } catch (error) {
+    const infrastructure = infrastructureErrorResponse(error, 'oauth')
+    if (infrastructure) {
+      return infrastructure
+    }
     console.error(providerName + ' callback error:', error) // nosemgrep
     const message = error instanceof Error ? error.message : 'OAuth callback failed'
     return new Response(message, { status: 400 })

--- a/src/utils/__tests__/infrastructure-error-response.test.ts
+++ b/src/utils/__tests__/infrastructure-error-response.test.ts
@@ -74,4 +74,23 @@ describe("infrastructureErrorResponse", () => {
     expect(body.error).toBe("temporarily_unavailable")
     expect(body.message).toContain("busy")
   })
+
+  it("uses temporarily_unavailable for oauth-format 503 and 504", async () => {
+    for (const err of [
+      new ClearAuthNetworkError("upstream", 503),
+      new ClearAuthTimeoutError("timed out"),
+    ]) {
+      const res = infrastructureErrorResponse(err, "oauth")
+      const body = await res!.json()
+      expect(body.error).toBe("temporarily_unavailable")
+    }
+  })
+
+  it("maps uncommon upstream 5xx to 503", async () => {
+    const res = infrastructureErrorResponse(
+      new ClearAuthNetworkError("upstream", 507),
+      "auth"
+    )
+    expect(res!.status).toBe(503)
+  })
 })

--- a/src/utils/__tests__/infrastructure-error-response.test.ts
+++ b/src/utils/__tests__/infrastructure-error-response.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest"
+import {
+  ClearAuthNetworkError,
+  ClearAuthRateLimitError,
+  ClearAuthSqlError,
+  ClearAuthTimeoutError,
+} from "../../errors.js"
+import { infrastructureErrorResponse } from "../infrastructure-error-response.js"
+
+describe("infrastructureErrorResponse", () => {
+  it("maps rate limit to 429 with Retry-After (auth format)", async () => {
+    const res = infrastructureErrorResponse(
+      new ClearAuthRateLimitError(45_000, { statusCode: 429 }),
+      "auth"
+    )
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(429)
+    expect(res!.headers.get("Retry-After")).toBe("45")
+    const body = await res!.json()
+    expect(body).toEqual({
+      error: "Service is busy. Please try again later.",
+      code: "RATE_LIMITED",
+    })
+  })
+
+  it("maps timeout to 504", async () => {
+    const res = infrastructureErrorResponse(new ClearAuthTimeoutError("timed out"), "auth")
+    expect(res!.status).toBe(504)
+    const body = await res!.json()
+    expect(body.code).toBe("GATEWAY_TIMEOUT")
+  })
+
+  it("passes through 503 from network errors", async () => {
+    const res = infrastructureErrorResponse(
+      new ClearAuthNetworkError("upstream", 503),
+      "auth"
+    )
+    expect(res!.status).toBe(503)
+    const body = await res!.json()
+    expect(body.code).toBe("SERVICE_UNAVAILABLE")
+  })
+
+  it("maps upstream 500 network errors to 503", async () => {
+    const res = infrastructureErrorResponse(
+      new ClearAuthNetworkError("upstream", 500),
+      "auth"
+    )
+    expect(res!.status).toBe(503)
+  })
+
+  it("maps SQL errors to generic 500", async () => {
+    const res = infrastructureErrorResponse(
+      new ClearAuthSqlError("relation missing", { code: "42P01" }),
+      "auth"
+    )
+    expect(res!.status).toBe(500)
+    const body = await res!.json()
+    expect(body).toEqual({ error: "Internal server error", code: "INTERNAL_ERROR" })
+    expect(body.error).not.toContain("relation")
+  })
+
+  it("returns null for unrecognized network errors", () => {
+    expect(
+      infrastructureErrorResponse(new ClearAuthNetworkError("bad request", 400), "auth")
+    ).toBeNull()
+  })
+
+  it("uses oauth error field for jwt-style responses", async () => {
+    const res = infrastructureErrorResponse(
+      new ClearAuthRateLimitError(1000),
+      "oauth"
+    )
+    const body = await res!.json()
+    expect(body.error).toBe("temporarily_unavailable")
+    expect(body.message).toContain("busy")
+  })
+})

--- a/src/utils/__tests__/infrastructure-error-response.test.ts
+++ b/src/utils/__tests__/infrastructure-error-response.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi, afterEach } from "vitest"
 import {
   ClearAuthNetworkError,
   ClearAuthRateLimitError,
@@ -8,11 +8,12 @@ import {
 import { infrastructureErrorResponse } from "../infrastructure-error-response.js"
 
 describe("infrastructureErrorResponse", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("maps rate limit to 429 with Retry-After (auth format)", async () => {
-    const res = infrastructureErrorResponse(
-      new ClearAuthRateLimitError(45_000, { statusCode: 429 }),
-      "auth"
-    )
+    const res = infrastructureErrorResponse(new ClearAuthRateLimitError(45_000), "auth")
     expect(res).not.toBeNull()
     expect(res!.status).toBe(429)
     expect(res!.headers.get("Retry-After")).toBe("45")
@@ -21,6 +22,17 @@ describe("infrastructureErrorResponse", () => {
       error: "Service is busy. Please try again later.",
       code: "RATE_LIMITED",
     })
+  })
+
+  it("logs rate limits at warn and 5xx at error", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    infrastructureErrorResponse(new ClearAuthRateLimitError(1000), "auth")
+    infrastructureErrorResponse(new ClearAuthNetworkError("upstream", 503), "auth")
+
+    expect(warnSpy).toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalled()
   })
 
   it("maps timeout to 504", async () => {
@@ -48,28 +60,21 @@ describe("infrastructureErrorResponse", () => {
     expect(res!.status).toBe(503)
   })
 
-  it("maps SQL errors to generic 500", async () => {
-    const res = infrastructureErrorResponse(
-      new ClearAuthSqlError("relation missing", { code: "42P01" }),
-      "auth"
-    )
-    expect(res!.status).toBe(500)
-    const body = await res!.json()
-    expect(body).toEqual({ error: "Internal server error", code: "INTERNAL_ERROR" })
-    expect(body.error).not.toContain("relation")
+  it("returns null for SQL errors (caller handles as unexpected)", () => {
+    expect(
+      infrastructureErrorResponse(new ClearAuthSqlError("relation missing", { code: "42P01" }), "auth")
+    ).toBeNull()
   })
 
   it("returns null for unrecognized network errors", () => {
     expect(
       infrastructureErrorResponse(new ClearAuthNetworkError("bad request", 400), "auth")
     ).toBeNull()
+    expect(infrastructureErrorResponse(new ClearAuthNetworkError("refused"), "auth")).toBeNull()
   })
 
   it("uses oauth error field for jwt-style responses", async () => {
-    const res = infrastructureErrorResponse(
-      new ClearAuthRateLimitError(1000),
-      "oauth"
-    )
+    const res = infrastructureErrorResponse(new ClearAuthRateLimitError(1000), "oauth")
     const body = await res!.json()
     expect(body.error).toBe("temporarily_unavailable")
     expect(body.message).toContain("busy")
@@ -92,15 +97,5 @@ describe("infrastructureErrorResponse", () => {
       "auth"
     )
     expect(res!.status).toBe(503)
-  })
-
-  it("uses server_error in oauth format for SQL failures", async () => {
-    const res = infrastructureErrorResponse(
-      new ClearAuthSqlError("relation missing", { code: "42P01" }),
-      "oauth"
-    )
-    const body = await res!.json()
-    expect(body.error).toBe("server_error")
-    expect(res!.status).toBe(500)
   })
 })

--- a/src/utils/__tests__/infrastructure-error-response.test.ts
+++ b/src/utils/__tests__/infrastructure-error-response.test.ts
@@ -60,10 +60,24 @@ describe("infrastructureErrorResponse", () => {
     expect(res!.status).toBe(503)
   })
 
-  it("returns null for SQL errors (caller handles as unexpected)", () => {
-    expect(
-      infrastructureErrorResponse(new ClearAuthSqlError("relation missing", { code: "42P01" }), "auth")
-    ).toBeNull()
+  it("sanitizes SQL errors to generic 500 without leaking details", async () => {
+    const res = infrastructureErrorResponse(
+      new ClearAuthSqlError("relation missing", { code: "42P01" }),
+      "auth"
+    )
+    expect(res!.status).toBe(500)
+    const body = await res!.json()
+    expect(body).toEqual({ error: "Internal server error", code: "INTERNAL_ERROR" })
+    expect(body.error).not.toContain("relation")
+  })
+
+  it("uses server_error in oauth format for SQL failures", async () => {
+    const res = infrastructureErrorResponse(
+      new ClearAuthSqlError("relation missing", { code: "42P01" }),
+      "oauth"
+    )
+    const body = await res!.json()
+    expect(body.error).toBe("server_error")
   })
 
   it("returns null for unrecognized network errors", () => {

--- a/src/utils/__tests__/infrastructure-error-response.test.ts
+++ b/src/utils/__tests__/infrastructure-error-response.test.ts
@@ -93,4 +93,14 @@ describe("infrastructureErrorResponse", () => {
     )
     expect(res!.status).toBe(503)
   })
+
+  it("uses server_error in oauth format for SQL failures", async () => {
+    const res = infrastructureErrorResponse(
+      new ClearAuthSqlError("relation missing", { code: "42P01" }),
+      "oauth"
+    )
+    const body = await res!.json()
+    expect(body.error).toBe("server_error")
+    expect(res!.status).toBe(500)
+  })
 })

--- a/src/utils/infrastructure-error-response.ts
+++ b/src/utils/infrastructure-error-response.ts
@@ -1,7 +1,6 @@
 import {
   ClearAuthNetworkError,
   ClearAuthRateLimitError,
-  ClearAuthSqlError,
   ClearAuthTimeoutError,
 } from "../errors.js"
 
@@ -16,12 +15,21 @@ type MappedInfrastructureError = {
 
 const PASS_THROUGH_NETWORK_STATUSES = new Set([502, 503, 504])
 
+function logInfrastructureError(error: unknown, status: number): void {
+  if (status >= 500) {
+    console.error("Infrastructure error:", error)
+  } else {
+    console.warn("Infrastructure error:", error)
+  }
+}
+
 function mapInfrastructureError(error: unknown): MappedInfrastructureError | null {
   if (error instanceof ClearAuthRateLimitError) {
     return {
       status: 429,
       code: "RATE_LIMITED",
       message: "Service is busy. Please try again later.",
+      // Minimum 1s — Retry-After must be a positive integer (seconds).
       retryAfterSeconds: Math.max(1, Math.ceil(error.retryAfter / 1000)),
     }
   }
@@ -44,25 +52,11 @@ function mapInfrastructureError(error: unknown): MappedInfrastructureError | nul
         message: "Service is temporarily unavailable. Please try again.",
       }
     }
+    // Upstream 4xx or missing statusCode (e.g. connection refused) — caller generic fallback.
     return null
   }
 
-  if (error instanceof ClearAuthSqlError) {
-    return {
-      status: 500,
-      code: "INTERNAL_ERROR",
-      message: "Internal server error",
-    }
-  }
-
   return null
-}
-
-function oauthErrorField(code: string): string {
-  if (code === "INTERNAL_ERROR") {
-    return "server_error"
-  }
-  return "temporarily_unavailable"
 }
 
 /**
@@ -78,6 +72,8 @@ export function infrastructureErrorResponse(
     return null
   }
 
+  logInfrastructureError(error, mapped.status)
+
   const headers: Record<string, string> = { "Content-Type": "application/json" }
   if (mapped.retryAfterSeconds !== undefined) {
     headers["Retry-After"] = String(mapped.retryAfterSeconds)
@@ -86,7 +82,7 @@ export function infrastructureErrorResponse(
   const body =
     format === "auth"
       ? { error: mapped.message, code: mapped.code }
-      : { error: oauthErrorField(mapped.code), message: mapped.message }
+      : { error: "temporarily_unavailable", message: mapped.message }
 
   return new Response(JSON.stringify(body), {
     status: mapped.status,

--- a/src/utils/infrastructure-error-response.ts
+++ b/src/utils/infrastructure-error-response.ts
@@ -36,16 +36,10 @@ function mapInfrastructureError(error: unknown): MappedInfrastructureError | nul
 
   if (error instanceof ClearAuthNetworkError) {
     const upstream = error.statusCode
-    if (upstream && PASS_THROUGH_NETWORK_STATUSES.has(upstream)) {
+    if (upstream && upstream >= 500) {
+      const status = PASS_THROUGH_NETWORK_STATUSES.has(upstream) ? upstream : 503
       return {
-        status: upstream,
-        code: "SERVICE_UNAVAILABLE",
-        message: "Service is temporarily unavailable. Please try again.",
-      }
-    }
-    if (upstream === 500) {
-      return {
-        status: 503,
+        status,
         code: "SERVICE_UNAVAILABLE",
         message: "Service is temporarily unavailable. Please try again.",
       }
@@ -98,8 +92,4 @@ export function infrastructureErrorResponse(
     status: mapped.status,
     headers,
   })
-}
-
-export function isInfrastructureClearAuthError(error: unknown): boolean {
-  return mapInfrastructureError(error) !== null
 }

--- a/src/utils/infrastructure-error-response.ts
+++ b/src/utils/infrastructure-error-response.ts
@@ -1,6 +1,7 @@
 import {
   ClearAuthNetworkError,
   ClearAuthRateLimitError,
+  ClearAuthSqlError,
   ClearAuthTimeoutError,
 } from "../errors.js"
 
@@ -56,6 +57,14 @@ function mapInfrastructureError(error: unknown): MappedInfrastructureError | nul
     return null
   }
 
+  if (error instanceof ClearAuthSqlError) {
+    return {
+      status: 500,
+      code: "INTERNAL_ERROR",
+      message: "Internal server error",
+    }
+  }
+
   return null
 }
 
@@ -72,7 +81,11 @@ export function infrastructureErrorResponse(
     return null
   }
 
-  logInfrastructureError(error, mapped.status)
+  if (mapped.code === "INTERNAL_ERROR") {
+    console.error("Unexpected SQL error:", error)
+  } else {
+    logInfrastructureError(error, mapped.status)
+  }
 
   const headers: Record<string, string> = { "Content-Type": "application/json" }
   if (mapped.retryAfterSeconds !== undefined) {
@@ -82,7 +95,10 @@ export function infrastructureErrorResponse(
   const body =
     format === "auth"
       ? { error: mapped.message, code: mapped.code }
-      : { error: "temporarily_unavailable", message: mapped.message }
+      : {
+          error: mapped.code === "INTERNAL_ERROR" ? "server_error" : "temporarily_unavailable",
+          message: mapped.message,
+        }
 
   return new Response(JSON.stringify(body), {
     status: mapped.status,

--- a/src/utils/infrastructure-error-response.ts
+++ b/src/utils/infrastructure-error-response.ts
@@ -1,0 +1,105 @@
+import {
+  ClearAuthNetworkError,
+  ClearAuthRateLimitError,
+  ClearAuthSqlError,
+  ClearAuthTimeoutError,
+} from "../errors.js"
+
+export type InfrastructureErrorFormat = "auth" | "oauth"
+
+type MappedInfrastructureError = {
+  status: number
+  code: string
+  message: string
+  retryAfterSeconds?: number
+}
+
+const PASS_THROUGH_NETWORK_STATUSES = new Set([502, 503, 504])
+
+function mapInfrastructureError(error: unknown): MappedInfrastructureError | null {
+  if (error instanceof ClearAuthRateLimitError) {
+    return {
+      status: 429,
+      code: "RATE_LIMITED",
+      message: "Service is busy. Please try again later.",
+      retryAfterSeconds: Math.max(1, Math.ceil(error.retryAfter / 1000)),
+    }
+  }
+
+  if (error instanceof ClearAuthTimeoutError) {
+    return {
+      status: 504,
+      code: "GATEWAY_TIMEOUT",
+      message: "Request timed out. Please try again.",
+    }
+  }
+
+  if (error instanceof ClearAuthNetworkError) {
+    const upstream = error.statusCode
+    if (upstream && PASS_THROUGH_NETWORK_STATUSES.has(upstream)) {
+      return {
+        status: upstream,
+        code: "SERVICE_UNAVAILABLE",
+        message: "Service is temporarily unavailable. Please try again.",
+      }
+    }
+    if (upstream === 500) {
+      return {
+        status: 503,
+        code: "SERVICE_UNAVAILABLE",
+        message: "Service is temporarily unavailable. Please try again.",
+      }
+    }
+    return null
+  }
+
+  if (error instanceof ClearAuthSqlError) {
+    return {
+      status: 500,
+      code: "INTERNAL_ERROR",
+      message: "Internal server error",
+    }
+  }
+
+  return null
+}
+
+function oauthErrorField(status: number): string {
+  if (status === 429 || status >= 500) {
+    return "temporarily_unavailable"
+  }
+  return "server_error"
+}
+
+/**
+ * Map Mech Storage / transport failures to a safe HTTP response, preserving status where appropriate.
+ * Returns null when the error should be handled by the caller's generic fallback.
+ */
+export function infrastructureErrorResponse(
+  error: unknown,
+  format: InfrastructureErrorFormat = "auth"
+): Response | null {
+  const mapped = mapInfrastructureError(error)
+  if (!mapped) {
+    return null
+  }
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" }
+  if (mapped.retryAfterSeconds !== undefined) {
+    headers["Retry-After"] = String(mapped.retryAfterSeconds)
+  }
+
+  const body =
+    format === "auth"
+      ? { error: mapped.message, code: mapped.code }
+      : { error: oauthErrorField(mapped.status), message: mapped.message }
+
+  return new Response(JSON.stringify(body), {
+    status: mapped.status,
+    headers,
+  })
+}
+
+export function isInfrastructureClearAuthError(error: unknown): boolean {
+  return mapInfrastructureError(error) !== null
+}

--- a/src/utils/infrastructure-error-response.ts
+++ b/src/utils/infrastructure-error-response.ts
@@ -58,11 +58,11 @@ function mapInfrastructureError(error: unknown): MappedInfrastructureError | nul
   return null
 }
 
-function oauthErrorField(status: number): string {
-  if (status === 429 || status >= 500) {
-    return "temporarily_unavailable"
+function oauthErrorField(code: string): string {
+  if (code === "INTERNAL_ERROR") {
+    return "server_error"
   }
-  return "server_error"
+  return "temporarily_unavailable"
 }
 
 /**
@@ -86,7 +86,7 @@ export function infrastructureErrorResponse(
   const body =
     format === "auth"
       ? { error: mapped.message, code: mapped.code }
-      : { error: oauthErrorField(mapped.status), message: mapped.message }
+      : { error: oauthErrorField(mapped.code), message: mapped.message }
 
   return new Response(JSON.stringify(body), {
     status: mapped.status,


### PR DESCRIPTION
## Summary

- Add `infrastructureErrorResponse()` to map `ClearAuthRateLimitError`, timeouts, and upstream 5xx from mech-sql-client to correct HTTP statuses (429/502–504/503) with sanitized messages.
- Wire mapper into auth, JWT, and device-auth error handlers so login/register no longer return generic 500 when mech-storage throttles (`APP_THROTTLED`).
- Add unit + handler-level tests for 429, 502, 503, 504, and oauth-format bodies.

Addresses mech-storage brain mail `msg-1780589911903-lm4yrf`.

## Smoke (SO-8)

**Category:** `SMOKE_MISSING` — no `scripts/smoke-*.ts` in this repo yet.

**Validation run instead:**
- `npx vitest run` on infrastructure test files (14 tests, all pass)
- Adversarial review: PROCEED (`.reviews/adversarial-review-2026-06-04-162730-infrastructure-error-pass-through.md`, gitignored)
- semgrep: 0 findings on changed files
- roborev: clean on `564150f`

## Test plan

- [x] `npx vitest run src/utils/__tests__/infrastructure-error-response.test.ts`
- [x] `npx vitest run src/auth/__tests__/infrastructure-error-handler.test.ts`
- [x] `npx vitest run src/jwt/__tests__/infrastructure-error-handler.test.ts`
- [x] `npx vitest run src/device-auth/__tests__/infrastructure-error-handler.test.ts`
- [ ] Manual: trigger mech-storage 429 and confirm `/auth/login` returns 429 + `Retry-After`

## Docs (SO-13)

Not required — no `scripts/` or `docs/` pipeline changes.


Made with [Cursor](https://cursor.com)