### PR TITLE
fix(config): preserve emailPassword + email in createClearAuth (verification emails never sent)

### DIFF
--- a/src/__tests__/createMechAuth.test.ts
+++ b/src/__tests__/createMechAuth.test.ts
@@ -85,6 +85,33 @@ describe("createClearAuth API", () => {
       expect(config.baseUrl).toBe('https://example.com')
     })
 
+    it("preserves emailPassword + email config (register/reset handlers depend on these)", async () => {
+      const sendVerificationEmail = async () => {}
+      const config = createClearAuth({
+        secret: 'test-secret',
+        database: { appId: TEST_APP_ID, apiKey: TEST_API_KEY },
+        baseUrl: 'https://example.com',
+        emailPassword: { enabled: true, requireEmailVerification: true },
+        email: { sendVerificationEmail },
+      })
+
+      // These fields were previously dropped by createClearAuth, so the register
+      // handler's `config.emailPassword?.requireEmailVerification` was always
+      // undefined and verification emails were never sent.
+      expect(config.emailPassword).toEqual({ enabled: true, requireEmailVerification: true })
+      expect(config.email?.sendVerificationEmail).toBe(sendVerificationEmail)
+    })
+
+    it("leaves emailPassword + email undefined when not provided", () => {
+      const config = createClearAuth({
+        secret: 'test-secret',
+        database: { appId: TEST_APP_ID, apiKey: TEST_API_KEY },
+        baseUrl: 'https://example.com',
+      })
+      expect(config.emailPassword).toBeUndefined()
+      expect(config.email).toBeUndefined()
+    })
+
     it("should create config with simplified database format", () => {
       const config = createClearAuth({
         secret: 'test-secret',

--- a/src/createMechAuth.ts
+++ b/src/createMechAuth.ts
@@ -111,6 +111,13 @@ export type CreateClearAuthOptions = {
   logger?: ClearAuthConfig['logger']
   /** JWT configuration for stateless token issuance (optional) */
   jwt?: ClearAuthConfig['jwt']
+  /**
+   * Email/password behavior, e.g. `requireEmailVerification` (optional).
+   * Required for the register handler to gate + trigger verification emails.
+   */
+  emailPassword?: ClearAuthConfig['emailPassword']
+  /** Transactional email callbacks (verification, reset, magic link) (optional). */
+  email?: ClearAuthConfig['email']
 }
 
 /**
@@ -271,6 +278,13 @@ export function createClearAuth(options: CreateClearAuthOptions): ClearAuthConfi
       passwordHasher: options.passwordHasher ?? createPbkdf2PasswordHasher(),
       logger,
       jwt: options.jwt,
+      // Preserve email-verification behavior + callbacks. Both are declared on
+      // ClearAuthConfig and read by the register/resend/reset handlers
+      // (config.emailPassword?.requireEmailVerification, config.email?.send*),
+      // but were previously dropped here — so verification/reset emails were
+      // never sent no matter how the caller configured them.
+      emailPassword: options.emailPassword,
+      email: options.email,
     }
 
     return config


### PR DESCRIPTION
## Summary
`createClearAuth()` silently dropped `emailPassword` and `email` from the config it returns, and didn't even declare them on `CreateClearAuthOptions`. Because `ClearAuthConfig` marks both optional, `tsc` never flagged the omission.

The register / resend-verification / reset / magic-link handlers gate on `config.emailPassword?.requireEmailVerification` and call `config.email?.send*`. With those fields dropped, `requireEmailVerification` was **always `undefined`** and **no verification / reset / magic-link email was ever sent**, regardless of how the caller configured `createClearAuth`.

Downstream symptom (root-caused from a live mech-browse signup outage): users register successfully but sit on a permanent "check your email" wall that no email ever clears.

Independently corroborated: **circle_computer** hit this same bug and works around it (`src/server/auth.ts` manually re-merges `emailPassword`/`email` onto the returned config, with a comment noting `createClearAuth` drops them).

## Change
- Declare `emailPassword?` / `email?` on `CreateClearAuthOptions`.
- Pass `options.emailPassword` + `options.email` through to the returned `ClearAuthConfig`.
- `createClearAuthNode` already spreads `...options` into `createClearAuth`, so the node variant is fixed by the same change.

## Blast radius (audited)
- Consumers not configuring email verification → no change (fields stay `undefined`).
- circle_computer → its post-return workaround overwrites with the same values → idempotent, no change.
- mech-browse → passes the config directly and now it actually works.
- Net behavior change is limited to apps that configured verification and silently had it not work — for them this restores the intended behavior.

## Test plan
- [x] `bun run test` — 555 passed (46 files), incl. 2 new regression tests (fields preserved when provided; `undefined` when omitted)
- [x] `bun run build` (tsc) clean
- [x] pre-push: semgrep 0 findings; roborev "No issues found"
- [x] adversarial PROCEED (`.reviews/adversarial-review-2026-07-05-131222-...md`); `createClearAuthNode` confirmed fixed via the shared assembly path

## Follow-up (after merge)
Republish `clearauth@0.7.1`, bump mech-browse to it, deploy, and live-verify the full signup → verification-email → verify → dashboard flow.

Generated with Claude Code
