### PR TITLE
fix(auth): stop exposing verification tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **Registration responses no longer expose email-verification credentials** (Codex, 2026-07-15)
-  - `POST /auth/register` retains the verification token internally for `sendVerificationEmail`, but omits it from JSON responses so clients, logs, and caches cannot capture the credential.
+  - `POST /auth/register` and `POST /auth/resend-verification` retain verification tokens internally for `sendVerificationEmail`, but omit them from JSON responses so clients, logs, and caches cannot capture the credential.
   - Configurations that require verification now fail before user creation unless `email.sendVerificationEmail` or `email.provider` is configured.
   - **Context:** mech-browse work order `msg-1784033326271-xb4xz4`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-07-15
+
+### Security
+
+- **Registration responses no longer expose email-verification credentials** (Codex, 2026-07-15)
+  - `POST /auth/register` retains the verification token internally for `sendVerificationEmail`, but omits it from JSON responses so clients, logs, and caches cannot capture the credential.
+  - **Context:** mech-browse work order `msg-1784033326271-xb4xz4`
+
 ## [0.7.1] - 2026-07-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Registration responses no longer expose email-verification credentials** (Codex, 2026-07-15)
   - `POST /auth/register` retains the verification token internally for `sendVerificationEmail`, but omits it from JSON responses so clients, logs, and caches cannot capture the credential.
+  - Configurations that require verification now fail before user creation unless `email.sendVerificationEmail` or `email.provider` is configured.
   - **Context:** mech-browse work order `msg-1784033326271-xb4xz4`
 
 ## [0.7.1] - 2026-07-05

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clearauth",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "ClearAuth: lightweight authentication library with Arctic OAuth, pluggable password hashing, and Kysely-backed storage",
   "keywords": [
     "clearauth",

--- a/src/__tests__/createMechAuth.test.ts
+++ b/src/__tests__/createMechAuth.test.ts
@@ -102,6 +102,17 @@ describe("createClearAuth API", () => {
       expect(config.email?.sendVerificationEmail).toBe(sendVerificationEmail)
     })
 
+    it("rejects required email verification without a delivery mechanism", () => {
+      expect(() =>
+        createClearAuth({
+          secret: 'test-secret',
+          database: { appId: TEST_APP_ID, apiKey: TEST_API_KEY },
+          baseUrl: 'https://example.com',
+          emailPassword: { enabled: true, requireEmailVerification: true },
+        })
+      ).toThrow('requireEmailVerification requires email.sendVerificationEmail or email.provider')
+    })
+
     it("leaves emailPassword + email undefined when not provided", () => {
       const config = createClearAuth({
         secret: 'test-secret',

--- a/src/__tests__/integration-auth-flow.test.ts
+++ b/src/__tests__/integration-auth-flow.test.ts
@@ -8,6 +8,7 @@ describe("Integration: Auth Flow (Register -> Login -> Session -> Logout)", () =
   const TEST_API_KEY = 'test-api-key'
   const TEST_SECRET = 'test-secret-key-at-least-32-chars-long'
   const hasher = createPbkdf2PasswordHasher()
+  const sendVerificationEmail = vi.fn(async () => {})
 
   const originalFetch = global.fetch
 
@@ -17,7 +18,9 @@ describe("Integration: Auth Flow (Register -> Login -> Session -> Logout)", () =
     database: {
       appId: TEST_APP_ID,
       apiKey: TEST_API_KEY,
-    }
+    },
+    emailPassword: { enabled: true, requireEmailVerification: true },
+    email: { sendVerificationEmail },
   })
 
   afterEach(() => {
@@ -77,6 +80,13 @@ describe("Integration: Auth Flow (Register -> Login -> Session -> Logout)", () =
     const registerData = await registerRes.json()
     expect(registerData.user.email).toBe(email)
     expect(registerData.sessionId).toBeDefined()
+    expect(registerData).not.toHaveProperty('verificationToken')
+    expect(sendVerificationEmail).toHaveBeenCalledOnce()
+    expect(sendVerificationEmail).toHaveBeenCalledWith(
+      email,
+      expect.stringMatching(/^[A-Za-z0-9_-]+$/),
+      expect.stringMatching(/^\/auth\/verify-email\?token=[A-Za-z0-9_-]+$/)
+    )
     const setCookie = registerRes.headers.get('Set-Cookie')
     expect(setCookie).toContain('session=')
 

--- a/src/__tests__/jwt-integration.test.ts
+++ b/src/__tests__/jwt-integration.test.ts
@@ -303,6 +303,7 @@ describe("JWT Integration: POST /auth/register with jwt config", () => {
     const data = await res.json()
     expect(data.user).toBeDefined()
     expect(data.sessionId).toBeDefined()
+    expect(data).not.toHaveProperty("verificationToken")
     expect(data.tokens).toBeDefined()
     expect(data.tokens.accessToken).toMatch(/^eyJ/)
     expect(data.tokens.refreshToken).toBeDefined()

--- a/src/auth/__tests__/parse-json-body.test.ts
+++ b/src/auth/__tests__/parse-json-body.test.ts
@@ -70,6 +70,27 @@ describe('parseJsonBody - Cloudflare Pages Functions Compatibility', () => {
   }
 
   describe('Valid JSON bodies', () => {
+    it('fails before registration when required verification has no delivery mechanism', async () => {
+      const database = createMockDb()
+      const invalidConfig: ClearAuthConfig = {
+        ...config,
+        database,
+        emailPassword: { enabled: true, requireEmailVerification: true },
+      }
+      const request = new Request('http://localhost:3000/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'test@example.com', password: 'Password123!' }),
+      })
+
+      const response = await handleAuthRequest(request, invalidConfig)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data).toEqual({ error: 'Internal server error', code: 'INTERNAL_ERROR' })
+      expect(database.selectFrom).not.toHaveBeenCalled()
+    })
+
     it('should parse valid JSON body successfully', async () => {
       const request = new Request('http://localhost:3000/auth/request-reset', {
         method: 'POST',

--- a/src/auth/__tests__/resend-verification-handler.test.ts
+++ b/src/auth/__tests__/resend-verification-handler.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Kysely } from 'kysely'
+import type { Database } from '../../database/schema.js'
+import type { ClearAuthConfig } from '../../types.js'
+import { handleAuthRequest } from '../handler.js'
+
+function createMockDb(): Kysely<Database> {
+  return {
+    selectFrom: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    executeTakeFirst: vi.fn(),
+    deleteFrom: vi.fn().mockReturnThis(),
+    execute: vi.fn(),
+    insertInto: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+  } as unknown as Kysely<Database>
+}
+
+describe('POST /auth/resend-verification', () => {
+  let database: Kysely<Database>
+  let sendVerificationEmail: ReturnType<typeof vi.fn>
+  let config: ClearAuthConfig
+
+  beforeEach(() => {
+    database = createMockDb()
+    sendVerificationEmail = vi.fn(async () => {})
+    config = {
+      database,
+      secret: 'test-secret',
+      baseUrl: 'https://example.com',
+      email: { sendVerificationEmail },
+    }
+
+    vi.mocked(
+      database
+        .selectFrom('users')
+        .select(['id', 'email', 'email_verified'])
+        .where('email', '=', 'user@example.com')
+        .executeTakeFirst
+    ).mockResolvedValue({
+      id: 'user-123',
+      email: 'user@example.com',
+      email_verified: false,
+    })
+    vi.mocked(
+      database.deleteFrom('email_verification_tokens').where('user_id', '=', 'user-123').execute
+    ).mockResolvedValue([])
+    vi.mocked(database.insertInto('email_verification_tokens').values({} as never).execute)
+      .mockResolvedValue([])
+    vi.clearAllMocks()
+  })
+
+  it('delivers the token internally but returns only a generic success result', async () => {
+    const request = new Request('https://example.com/auth/resend-verification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'user@example.com' }),
+    })
+
+    const response = await handleAuthRequest(request, config)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ success: true })
+    expect(data).not.toHaveProperty('token')
+    expect(sendVerificationEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      expect.stringMatching(/^[A-Za-z0-9_-]+$/),
+      expect.stringMatching(/^\/auth\/verify-email\?token=[A-Za-z0-9_-]+$/)
+    )
+  })
+
+  it('fails before token creation when no delivery mechanism is configured', async () => {
+    const request = new Request('https://example.com/auth/resend-verification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'user@example.com' }),
+    })
+
+    const response = await handleAuthRequest(request, { ...config, email: undefined })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Internal server error', code: 'INTERNAL_ERROR' })
+    expect(database.selectFrom).not.toHaveBeenCalled()
+  })
+})

--- a/src/auth/__tests__/resend-verification-handler.test.ts
+++ b/src/auth/__tests__/resend-verification-handler.test.ts
@@ -109,4 +109,32 @@ describe('POST /auth/resend-verification', () => {
     expect(data).toEqual({ success: true })
     expect(sendVerificationEmail).not.toHaveBeenCalled()
   })
+
+  it('returns the same public result when the email is already verified', async () => {
+    vi.mocked(
+      database
+        .selectFrom('users')
+        .select(['id', 'email', 'email_verified'])
+        .where('email', '=', 'verified@example.com')
+        .executeTakeFirst
+    ).mockResolvedValueOnce({
+      id: 'verified-user',
+      email: 'verified@example.com',
+      email_verified: true,
+    })
+    vi.clearAllMocks()
+
+    const request = new Request('https://example.com/auth/resend-verification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'verified@example.com' }),
+    })
+
+    const response = await handleAuthRequest(request, config)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ success: true })
+    expect(sendVerificationEmail).not.toHaveBeenCalled()
+  })
 })

--- a/src/auth/__tests__/resend-verification-handler.test.ts
+++ b/src/auth/__tests__/resend-verification-handler.test.ts
@@ -85,4 +85,28 @@ describe('POST /auth/resend-verification', () => {
     expect(data).toEqual({ error: 'Internal server error', code: 'INTERNAL_ERROR' })
     expect(database.selectFrom).not.toHaveBeenCalled()
   })
+
+  it('returns the same public result when the email is unknown', async () => {
+    vi.mocked(
+      database
+        .selectFrom('users')
+        .select(['id', 'email', 'email_verified'])
+        .where('email', '=', 'unknown@example.com')
+        .executeTakeFirst
+    ).mockResolvedValueOnce(undefined)
+    vi.clearAllMocks()
+
+    const request = new Request('https://example.com/auth/resend-verification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'unknown@example.com' }),
+    })
+
+    const response = await handleAuthRequest(request, config)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ success: true })
+    expect(sendVerificationEmail).not.toHaveBeenCalled()
+  })
 })

--- a/src/auth/handler.ts
+++ b/src/auth/handler.ts
@@ -169,8 +169,7 @@ function errorResponse(error: any): Response {
  *     "avatar_url": null,
  *     "created_at": "2025-01-01T00:00:00.000Z"
  *   },
- *   "sessionId": "session_id",
- *   "verificationToken": "token"
+ *   "sessionId": "session_id"
  * }
  * ```
  */

--- a/src/auth/handler.ts
+++ b/src/auth/handler.ts
@@ -280,11 +280,17 @@ async function handleVerifyEmail(request: Request, config: ClearAuthConfig): Pro
  * Response:
  * ```json
  * {
- *   "token": "new_verification_token"
+ *   "success": true
  * }
  * ```
  */
 async function handleResendVerification(request: Request, config: ClearAuthConfig): Promise<Response> {
+  if (!hasVerificationEmailDelivery(config)) {
+    throw new Error(
+      '[ClearAuth] resend verification requires email.sendVerificationEmail or email.provider'
+    )
+  }
+
   const body = await parseJsonBody(request)
   const { email } = body
 
@@ -304,7 +310,7 @@ async function handleResendVerification(request: Request, config: ClearAuthConfi
     // Don't fail the request if email sending fails
   }
 
-  return jsonResponse(result)
+  return jsonResponse({ success: true })
 }
 
 /**

--- a/src/auth/handler.ts
+++ b/src/auth/handler.ts
@@ -298,7 +298,15 @@ async function handleResendVerification(request: Request, config: ClearAuthConfi
     throw new AuthError('Email is required', 'MISSING_EMAIL', 400)
   }
 
-  const result = await resendVerificationEmail(config.database, email)
+  let result: Awaited<ReturnType<typeof resendVerificationEmail>>
+  try {
+    result = await resendVerificationEmail(config.database, email)
+  } catch (error) {
+    if (error instanceof AuthError && error.code === 'EMAIL_SENT') {
+      return jsonResponse({ success: true })
+    }
+    throw error
+  }
   
   // Send the new verification email
   const emailManager = new EmailManager(config)

--- a/src/auth/handler.ts
+++ b/src/auth/handler.ts
@@ -25,7 +25,7 @@ import {
 } from '../oauth/callbacks.js'
 import { AuthError, isValidReturnTo } from './utils.js'
 import { toPublicUser } from '../database/schema.js'
-import { EmailManager } from '../email/manager.js'
+import { EmailManager, hasVerificationEmailDelivery } from '../email/manager.js'
 import { issueTokenPair } from '../jwt/issue-token-pair.js'
 import { revokeRefreshTokenByValue } from '../jwt/refresh-tokens.js'
 import type { Kysely } from 'kysely'
@@ -174,6 +174,15 @@ function errorResponse(error: any): Response {
  * ```
  */
 async function handleRegister(request: Request, config: ClearAuthConfig): Promise<Response> {
+  if (
+    config.emailPassword?.requireEmailVerification &&
+    !hasVerificationEmailDelivery(config)
+  ) {
+    throw new Error(
+      '[ClearAuth] requireEmailVerification requires email.sendVerificationEmail or email.provider'
+    )
+  }
+
   const body = await parseJsonBody(request)
   const { email, password } = body
 

--- a/src/auth/handler.ts
+++ b/src/auth/handler.ts
@@ -302,7 +302,10 @@ async function handleResendVerification(request: Request, config: ClearAuthConfi
   try {
     result = await resendVerificationEmail(config.database, email)
   } catch (error) {
-    if (error instanceof AuthError && error.code === 'EMAIL_SENT') {
+    if (
+      error instanceof AuthError &&
+      (error.code === 'EMAIL_SENT' || error.code === 'ALREADY_VERIFIED')
+    ) {
       return jsonResponse({ success: true })
     }
     throw error

--- a/src/auth/register.ts
+++ b/src/auth/register.ts
@@ -143,7 +143,6 @@ export interface RegisterUserResult {
     created_at: Date
   }
   sessionId: string
-  verificationToken: string
 }
 
 /**
@@ -158,7 +157,6 @@ export interface RegisterUserResult {
 export function toPublicRegisterResult(result: {
   user: User
   sessionId: string
-  verificationToken: string
 }): RegisterUserResult {
   return {
     user: {
@@ -170,6 +168,5 @@ export function toPublicRegisterResult(result: {
       created_at: result.user.created_at,
     },
     sessionId: result.sessionId,
-    verificationToken: result.verificationToken,
   }
 }

--- a/src/createMechAuth.ts
+++ b/src/createMechAuth.ts
@@ -12,6 +12,7 @@ import { ClearAuthConfigError } from "./errors.js"
 import { getDefaultLogger } from "./logger.js"
 import type { ClearAuthConfig } from "./types.js"
 import { createPbkdf2PasswordHasher } from "./password-hasher.js"
+import { hasVerificationEmailDelivery } from "./email/manager.js"
 
 // ============================================================================
 // Session & Cookie Presets
@@ -221,6 +222,15 @@ export function createClearAuth(options: CreateClearAuthOptions): ClearAuthConfi
 
   if (!options.baseUrl) {
     throw new ClearAuthConfigError("baseUrl is required", { isProduction: options.isProduction })
+  }
+
+  if (
+    options.emailPassword?.requireEmailVerification &&
+    !hasVerificationEmailDelivery(options)
+  ) {
+    throw new ClearAuthConfigError(
+      "requireEmailVerification requires email.sendVerificationEmail or email.provider"
+    )
   }
 
   // Warn about development defaults

--- a/src/email/manager.ts
+++ b/src/email/manager.ts
@@ -1,6 +1,10 @@
 import type { ClearAuthConfig, EmailProvider } from '../types.js'
 import { emailTemplates } from './templates.js'
 
+export function hasVerificationEmailDelivery(config: Pick<ClearAuthConfig, 'email'>): boolean {
+  return Boolean(config.email?.sendVerificationEmail || config.email?.provider)
+}
+
 /**
  * Email Manager
  * 


### PR DESCRIPTION
## Summary

- remove `verificationToken` from public `POST /auth/register` responses
- retain the token internally for verification-email delivery
- fail before user creation when verification is required but no email callback/provider is configured
- prepare the `0.7.2` security patch release

## Security context

Work order: `msg-1784033326271-xb4xz4`

The response previously exposed a valid email-verification bearer credential to browser clients, logs, and caches.

## Validation

- `bun run build`
- `bun run test`: 46 files, 557 tests passed
- focused handler/config smoke: 52 tests passed
- Semgrep: 0 findings
- roborev: clean after addressing the missing-delivery configuration finding
- `npm_config_cache=/tmp/clearauth-npm-cache npm pack --dry-run`: valid `clearauth@0.7.2` package

## Smoke

`PASS (LIBRARY_NO_SERVER)`: ClearAuth has no self-started application server in this repository; real Request/Response handler integration tests cover registration with and without JWT issuance.
