### PR TITLE
docs(oauth): define external adapter roadmap

### DIFF
--- a/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -64,17 +64,18 @@ The names are illustrative; the behavioral contract is normative.
 ```ts
 type OAuthAccountOutcome = 'created' | 'linked' | 'returning'
 
-interface OAuthTransactionBinding {
+interface OAuthCallbackEvidence {
+  returnedState: string
   providerKey: string
   redirectUri: string
-  expectedIssuer?: string
+  returnedIssuer?: string
   browserBindingSecret: string
+  now: Date
 }
 
 interface OAuthTransactionStore {
   create(transaction: NewOAuthTransaction): Promise<OAuthTransaction>
-  get(id: string): Promise<OAuthTransaction | null>
-  consume(id: string, expected: OAuthTransactionBinding): Promise<OAuthTransaction | null>
+  validateAndConsume(id: string, evidence: OAuthCallbackEvidence): Promise<OAuthTransaction | null>
 }
 
 interface OAuthAdapter {
@@ -90,6 +91,8 @@ interface OAuthAdapterResult {
   credentials?: OAuthUpstreamCredentials
 }
 ```
+
+`validateAndConsume()` is one atomic operation. It compares the stored state hash, provider, redirect URI, expected issuer, browser-binding hash, and expiry against the callback evidence, verifies `consumedAt` is unset, and marks the transaction consumed only if every invariant passes. Callback code must not implement this as `get() -> validate -> consume()`.
 
 After adapter callback success, ClearAuth resolves the generic OAuth account and outcome, then runs the existing session-cookie pipeline and optional `issueTokenPair()` JWT pipeline. Adapters do not issue ClearAuth sessions or JWTs directly.
 

--- a/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -4,6 +4,7 @@
 **Feature**: OAuth Transactions and External Adapters
 **Source**: Ohok work order `msg-1784149461545-e23oby`
 **Status**: Proposed
+**Created**: 2026-07-15
 **Priority**: High
 **Task list**: `tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md`
 
@@ -69,6 +70,7 @@ interface OAuthCallbackEvidence {
   providerKey: string
   redirectUri: string
   returnedIssuer?: string
+  /** Raw per-flow cookie value. Never persist or log this value. */
   browserBindingSecret: string
   now: Date
 }
@@ -90,9 +92,18 @@ interface OAuthAdapterResult {
   profile: { name?: string | null; avatarUrl?: string | null }
   credentials?: OAuthUpstreamCredentials
 }
+
+interface OAuthUpstreamCredentials {
+  accessToken?: string
+  refreshToken?: string
+  expiresAt?: Date
+  scope?: string
+}
 ```
 
 `validateAndConsume()` is one atomic operation. It compares the stored state hash, provider, redirect URI, expected issuer, browser-binding hash, and expiry against the callback evidence, verifies `consumedAt` is unset, and marks the transaction consumed only if every invariant passes. Callback code must not implement this as `get() -> validate -> consume()`.
+
+`OAuthUpstreamCredentials` is adapter-to-library server-side data only. The credential sink encrypts it before persistence; no raw credential, browser-binding secret, or private DPoP key may be logged or exposed through a browser-facing API.
 
 After adapter callback success, ClearAuth resolves the generic OAuth account and outcome, then runs the existing session-cookie pipeline and optional `issueTokenPair()` JWT pipeline. Adapters do not issue ClearAuth sessions or JWTs directly.
 
@@ -128,14 +139,16 @@ Secrets, raw authorization codes, access tokens, refresh tokens, PKCE verifiers,
 
 ## 8. Delivery Strategy
 
-1. Transaction core and compatibility bridge for current providers.
-2. Callback outcomes and generic OAuth account storage.
-3. External adapter registration and routing through the existing success pipeline.
-4. Optional discovery, DPoP, and PAR hooks.
-5. Upstream credential sink, refresh lock, disconnect, and revocation semantics.
-6. AT Protocol reference adapter maintained by Ohok or a separate integration package.
+1. Transaction core and compatibility bridge for current providers. Owner: ClearAuth.
+2. Callback outcomes and generic OAuth account storage. Owner: ClearAuth.
+3. External adapter registration and routing through the existing success pipeline. Owner: ClearAuth.
+4. Optional discovery, DPoP, and PAR hooks. Owner: ClearAuth.
+5. Upstream credential sink, refresh lock, disconnect, and revocation semantics. Owner: ClearAuth.
+6. AT Protocol reference adapter maintained by Ohok or a separate integration package. Owner: Ohok.
 
 Each phase should be a separate reviewed PR. Migration of existing provider columns must be additive first; destructive cleanup requires a later major release.
+
+During the Phase 2 deprecation window, retain `upsertOAuthUser()` as a compatibility wrapper returning `Promise<User>` for existing callers. Introduce the outcome-aware account-resolution API alongside it; do not change the exported legacy function's return contract in place.
 
 Phase 1 intentionally does not accept the legacy shared OAuth cookies on the transaction path. A conventional OAuth flow started before deployment may fail closed at callback and require the user to retry; accepting an unbound legacy cookie would preserve the collision weakness the phase removes. Release notes and deployment runbooks must call out this bounded transition.
 
@@ -165,4 +178,4 @@ Until phases 1 through 3 and the applicable DPoP/PAR hooks are shipped, ClearAut
 | G8 | No SSRF-safe remote discovery policy surface |
 | G9 | No serialized upstream refresh lifecycle |
 | G10 | Upstream revocation and disconnect are only partially supported |
-| G11 | No `created | linked | returning` callback outcome |
+| G11 | No create/link/return callback outcome |

--- a/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -178,4 +178,4 @@ Until phases 1 through 3 and the applicable DPoP/PAR hooks are shipped, ClearAut
 | G8 | No SSRF-safe remote discovery policy surface |
 | G9 | No serialized upstream refresh lifecycle |
 | G10 | Upstream revocation and disconnect are only partially supported |
-| G11 | No create/link/return callback outcome |
+| G11 | No `created`, `linked`, or `returning` callback outcome |

--- a/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -40,7 +40,7 @@ The authoritative [AT Protocol OAuth specification](https://atproto.com/specs/oa
 ClearAuth owns:
 
 - An `OAuthTransaction` model with a random identifier, provider key, state hash, PKCE material, issuer and redirect bindings, opaque adapter metadata, browser binding, expiry, and consumed timestamp.
-- An `OAuthTransactionStore` with create, load, and atomic consume operations. Consumption must be single-use.
+- An `OAuthTransactionStore` with create and atomic validate-and-consume operations. Consumption must be single-use; callback code has no separate read operation.
 - One opaque browser-binding cookie per transaction, named with both the provider key and transaction ID. Its value is an independent high-entropy random secret whose hash is stored in the transaction. The callback derives the expected cookie name from the state-bound transaction reference, verifies the secret, atomically consumes the server-side transaction, and deletes only that transaction's cookie. IP addresses and User-Agent strings are audit context, not authentication factors. No flow reads or overwrites a shared OAuth cookie.
 - Callback validation before adapter token exchange, including state, provider, expiry, redirect URI, expected issuer, browser binding, and one-time consumption.
 - An `OAuthAdapter` contract that starts a flow and exchanges a validated callback for a normalized external identity and optional upstream credentials.

--- a/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -38,7 +38,7 @@ ClearAuth owns:
 
 - An `OAuthTransaction` model with a random identifier, provider key, state hash, PKCE material, issuer and redirect bindings, opaque adapter metadata, browser binding, expiry, and consumed timestamp.
 - An `OAuthTransactionStore` with create, load, and atomic consume operations. Consumption must be single-use.
-- One opaque transaction-pointer cookie. Cookie names must be namespaced by provider and transaction ID, or the pointer must resolve to server-side state that supports concurrent flows.
+- One opaque pointer cookie per transaction, named with both the provider key and transaction ID. The callback derives the expected cookie name from the state-bound transaction reference, atomically consumes the server-side transaction, and deletes only that transaction's cookie. No flow reads or overwrites a shared OAuth cookie.
 - Callback validation before adapter token exchange, including state, provider, expiry, redirect URI, expected issuer, browser binding, and one-time consumption.
 - An `OAuthAdapter` contract that starts a flow and exchanges a validated callback for a normalized external identity and optional upstream credentials.
 - A generic `oauth_accounts` identity model instead of adding provider columns for each new adapter.
@@ -133,4 +133,3 @@ Ohok can implement AT Protocol OAuth without forking ClearAuth when it can:
 5. Revoke or disconnect the upstream account without bypassing ClearAuth's security model.
 
 Until phases 1 through 3 and the applicable DPoP/PAR hooks are shipped, ClearAuth is an explicit no-fit for Ohok's production AT Protocol OAuth flow.
-

--- a/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -1,0 +1,136 @@
+# PRD: Provider-Agnostic OAuth Extension Surface
+
+**PRD ID**: 0005
+**Feature**: OAuth Transactions and External Adapters
+**Source**: Ohok work order `msg-1784149461545-e23oby`
+**Status**: Proposed
+**Priority**: High
+
+## 1. Decision
+
+ClearAuth should expose a provider-agnostic OAuth transaction and adapter surface. It should not add AT Protocol as another hard-coded provider or own Ohok-specific discovery and storage policy.
+
+This is the recommended extension-surface response to Ohok. The work should be delivered in bounded, backward-compatible phases. Conventional providers must continue through the same session and JWT issuance pipeline while AT Protocol-specific behavior is supplied by an external adapter.
+
+## 2. Evidence
+
+The current implementation is not a safe base for AT Protocol OAuth:
+
+- `OAuthProvider` is a fixed union and user identities are stored in provider-specific columns.
+- Login state and PKCE use global `oauth_state` and `oauth_code_verifier` cookies, so parallel flows can overwrite one another.
+- Callback validation is delegated to provider handlers using only the cookie state and returned state. There is no atomic transaction consumption or binding to provider, issuer, redirect URI, or browser context.
+- `upsertOAuthUser()` returns only a user, so callers cannot distinguish `created`, `linked`, and `returning` outcomes.
+- Upstream access and refresh tokens are returned transiently and have no first-class persistence, refresh serialization, disconnect, or revocation contract.
+
+The authoritative [AT Protocol OAuth specification](https://atproto.com/specs/oauth) requires dynamic server discovery, PKCE, PAR, DPoP, public client metadata, issuer validation, and account binding. The official [client implementation guide](https://docs.bsky.app/docs/advanced-guides/oauth-client) also requires per-session DPoP keys and nonce handling.
+
+## 3. Goals
+
+1. Make OAuth initiation and callbacks transaction-bound, atomic, and safe across tabs and providers.
+2. Allow external adapters to use ClearAuth's normal account, session, cookie, and optional JWT pipeline without forking the library.
+3. Return an explicit `created | linked | returning` callback outcome.
+4. Define optional interfaces for remote discovery, DPoP/PAR state, upstream token persistence, refresh locking, and revocation.
+5. Preserve all existing conventional provider behavior and routes.
+
+## 4. Library Boundary
+
+ClearAuth owns:
+
+- An `OAuthTransaction` model with a random identifier, provider key, state hash, PKCE material, issuer and redirect bindings, opaque adapter metadata, browser binding, expiry, and consumed timestamp.
+- An `OAuthTransactionStore` with create, load, and atomic consume operations. Consumption must be single-use.
+- One opaque transaction-pointer cookie. Cookie names must be namespaced by provider and transaction ID, or the pointer must resolve to server-side state that supports concurrent flows.
+- Callback validation before adapter token exchange, including state, provider, expiry, redirect URI, expected issuer, browser binding, and one-time consumption.
+- An `OAuthAdapter` contract that starts a flow and exchanges a validated callback for a normalized external identity and optional upstream credentials.
+- A generic `oauth_accounts` identity model instead of adding provider columns for each new adapter.
+- The account-resolution pipeline and an explicit `created | linked | returning` result.
+- Optional, provider-neutral hooks for discovery policy, proof-key lifecycle, upstream credential storage, refresh locking, and revocation.
+- Existing session creation, cookie issuance, and optional ClearAuth JWT issuance after a successful adapter callback.
+
+ClearAuth does not own by default:
+
+- Handle to DID, DID to PDS, or PDS to authorization-server rules.
+- Ohok's SSRF policy implementation or PDS compatibility matrix.
+- AT Protocol client-metadata hosting. ClearAuth may generate and validate the document, but the consumer must publish it over HTTPS.
+- AT Protocol scopes, XRPC behavior, custom feeds, or other application logic.
+- Ohok's encryption backend, credential retention policy, or provider-specific refresh schedule.
+
+## 5. Required Interfaces
+
+The names are illustrative; the behavioral contract is normative.
+
+```ts
+type OAuthAccountOutcome = 'created' | 'linked' | 'returning'
+
+interface OAuthTransactionStore {
+  create(transaction: NewOAuthTransaction): Promise<OAuthTransaction>
+  get(id: string): Promise<OAuthTransaction | null>
+  consume(id: string, expected: OAuthTransactionBinding): Promise<OAuthTransaction | null>
+}
+
+interface OAuthAdapter {
+  key: string
+  start(context: OAuthStartContext): Promise<OAuthStartResult>
+  callback(context: ValidatedOAuthCallbackContext): Promise<OAuthAdapterResult>
+  revoke?(context: OAuthRevocationContext): Promise<void>
+}
+
+interface OAuthAdapterResult {
+  identity: { provider: string; subject: string; email?: string; emailVerified?: boolean }
+  profile: { name?: string | null; avatarUrl?: string | null }
+  credentials?: OAuthUpstreamCredentials
+}
+```
+
+Secrets, raw authorization codes, access tokens, refresh tokens, PKCE verifiers, and private DPoP keys must never be returned in public HTTP responses or callback hooks intended for browser clients.
+
+## 6. Functional Requirements
+
+| ID | Requirement | Gap |
+|---|---|---|
+| FR-1 | Transactions MUST bind state to provider, redirect URI, browser context, expiry, and adapter metadata. | G2 |
+| FR-2 | Parallel provider and same-provider flows MUST not overwrite each other. | G3 |
+| FR-3 | Callback transaction consumption MUST be atomic and replay-safe. | G2, G3 |
+| FR-4 | External adapters MUST route through ClearAuth account, session, cookie, and JWT issuance. | G1 |
+| FR-5 | Callback completion MUST expose `created`, `linked`, or `returning` to a server-side hook. | G11 |
+| FR-6 | Account storage MUST support arbitrary provider keys and subjects without schema columns per provider. | G1 |
+| FR-7 | Discovery MUST be pluggable and receive explicit redirect, scheme, address, port, timeout, and response-size policy hooks. | G7, G8 |
+| FR-8 | DPoP key and nonce lifecycle MUST be pluggable per transaction and upstream session. | G5 |
+| FR-9 | Adapters MUST be able to perform PAR and persist returned request metadata in the transaction. | G6 |
+| FR-10 | Upstream credential storage MUST use an explicit server-side sink and support serialized refresh. | G9 |
+| FR-11 | Disconnect MUST revoke upstream grants when supported and remove local credentials without revoking unrelated ClearAuth sessions by default. | G10 |
+| FR-12 | A helper MAY generate and validate client metadata, but publication and HTTPS deployment remain consumer responsibilities. | G4 |
+
+## 7. Security Gates
+
+- No raw global `oauth_state` or `oauth_code_verifier` cookie names remain in the transaction-based path.
+- Two concurrent flows in separate tabs complete independently.
+- A callback can consume its transaction exactly once; a second callback fails before token exchange.
+- Provider, issuer, redirect URI, expired state, and browser-binding mismatches fail closed.
+- Discovery policy denies non-HTTPS endpoints, credentials in URLs, forbidden ports and addresses, unsafe redirects, oversized bodies, and DNS rebinding.
+- DPoP private keys and upstream tokens remain server-side and are redacted from errors and logs.
+- Existing GitHub, Google, Discord, Apple, Microsoft, LinkedIn, and Meta tests remain green.
+- Extension interfaces are documented before implementation merges.
+
+## 8. Delivery Strategy
+
+1. Transaction core and compatibility bridge for current providers.
+2. Callback outcomes and generic OAuth account storage.
+3. External adapter registration and routing through the existing success pipeline.
+4. Optional discovery, DPoP, and PAR hooks.
+5. Upstream credential sink, refresh lock, disconnect, and revocation semantics.
+6. AT Protocol reference adapter maintained by Ohok or a separate integration package.
+
+Each phase should be a separate reviewed PR. Migration of existing provider columns must be additive first; destructive cleanup requires a later major release.
+
+## 9. Acceptance Criteria for Ohok
+
+Ohok can implement AT Protocol OAuth without forking ClearAuth when it can:
+
+1. Register an external adapter and start a transaction with opaque discovery and DPoP metadata.
+2. Complete an issuer-bound, one-time callback through ClearAuth's account and session pipeline.
+3. Persist upstream credentials through a server-side sink and serialize refreshes.
+4. Receive a server-side `created | linked | returning` outcome.
+5. Revoke or disconnect the upstream account without bypassing ClearAuth's security model.
+
+Until phases 1 through 3 and the applicable DPoP/PAR hooks are shipped, ClearAuth is an explicit no-fit for Ohok's production AT Protocol OAuth flow.
+

--- a/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -5,6 +5,9 @@
 **Source**: Ohok work order `msg-1784149461545-e23oby`
 **Status**: Proposed
 **Priority**: High
+**Task list**: `tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md`
+
+This PRD intentionally uses a decision-record structure because its primary deliverable is an architecture boundary and extension contract, not a single end-user feature.
 
 ## 1. Decision
 
@@ -38,7 +41,7 @@ ClearAuth owns:
 
 - An `OAuthTransaction` model with a random identifier, provider key, state hash, PKCE material, issuer and redirect bindings, opaque adapter metadata, browser binding, expiry, and consumed timestamp.
 - An `OAuthTransactionStore` with create, load, and atomic consume operations. Consumption must be single-use.
-- One opaque pointer cookie per transaction, named with both the provider key and transaction ID. The callback derives the expected cookie name from the state-bound transaction reference, atomically consumes the server-side transaction, and deletes only that transaction's cookie. No flow reads or overwrites a shared OAuth cookie.
+- One opaque browser-binding cookie per transaction, named with both the provider key and transaction ID. Its value is an independent high-entropy random secret whose hash is stored in the transaction. The callback derives the expected cookie name from the state-bound transaction reference, verifies the secret, atomically consumes the server-side transaction, and deletes only that transaction's cookie. IP addresses and User-Agent strings are audit context, not authentication factors. No flow reads or overwrites a shared OAuth cookie.
 - Callback validation before adapter token exchange, including state, provider, expiry, redirect URI, expected issuer, browser binding, and one-time consumption.
 - An `OAuthAdapter` contract that starts a flow and exchanges a validated callback for a normalized external identity and optional upstream credentials.
 - A generic `oauth_accounts` identity model instead of adding provider columns for each new adapter.
@@ -61,6 +64,13 @@ The names are illustrative; the behavioral contract is normative.
 ```ts
 type OAuthAccountOutcome = 'created' | 'linked' | 'returning'
 
+interface OAuthTransactionBinding {
+  providerKey: string
+  redirectUri: string
+  expectedIssuer?: string
+  browserBindingSecret: string
+}
+
 interface OAuthTransactionStore {
   create(transaction: NewOAuthTransaction): Promise<OAuthTransaction>
   get(id: string): Promise<OAuthTransaction | null>
@@ -80,6 +90,8 @@ interface OAuthAdapterResult {
   credentials?: OAuthUpstreamCredentials
 }
 ```
+
+After adapter callback success, ClearAuth resolves the generic OAuth account and outcome, then runs the existing session-cookie pipeline and optional `issueTokenPair()` JWT pipeline. Adapters do not issue ClearAuth sessions or JWTs directly.
 
 Secrets, raw authorization codes, access tokens, refresh tokens, PKCE verifiers, and private DPoP keys must never be returned in public HTTP responses or callback hooks intended for browser clients.
 
@@ -122,6 +134,8 @@ Secrets, raw authorization codes, access tokens, refresh tokens, PKCE verifiers,
 
 Each phase should be a separate reviewed PR. Migration of existing provider columns must be additive first; destructive cleanup requires a later major release.
 
+Phase 1 intentionally does not accept the legacy shared OAuth cookies on the transaction path. A conventional OAuth flow started before deployment may fail closed at callback and require the user to retry; accepting an unbound legacy cookie would preserve the collision weakness the phase removes. Release notes and deployment runbooks must call out this bounded transition.
+
 ## 9. Acceptance Criteria for Ohok
 
 Ohok can implement AT Protocol OAuth without forking ClearAuth when it can:
@@ -133,3 +147,19 @@ Ohok can implement AT Protocol OAuth without forking ClearAuth when it can:
 5. Revoke or disconnect the upstream account without bypassing ClearAuth's security model.
 
 Until phases 1 through 3 and the applicable DPoP/PAR hooks are shipped, ClearAuth is an explicit no-fit for Ohok's production AT Protocol OAuth flow.
+
+## 10. Gap Matrix
+
+| Gap | Short description |
+|---|---|
+| G1 | No AT Protocol provider or external adapter surface |
+| G2 | State is not bound to a complete authorization transaction |
+| G3 | Global state and PKCE cookies collide across parallel flows |
+| G4 | No client-metadata generation or publication support |
+| G5 | No per-session DPoP key and nonce lifecycle |
+| G6 | No PAR support |
+| G7 | No handle/DID/PDS/authorization-server discovery path |
+| G8 | No SSRF-safe remote discovery policy surface |
+| G9 | No serialized upstream refresh lifecycle |
+| G10 | Upstream revocation and disconnect are only partially supported |
+| G11 | No `created | linked | returning` callback outcome |

--- a/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -1,0 +1,62 @@
+# Tasks: Provider-Agnostic OAuth Extension Surface
+
+**PRD**: `tasks/0005-prd-provider-agnostic-oauth-extension-surface.md`
+**Source**: Ohok messages `msg-1784149461545-e23oby` and `msg-1784149805359-bytxck`
+**Status**: Proposed
+
+## Phase 1: Transaction Core
+
+- [ ] Define `OAuthTransaction`, binding, and store interfaces.
+- [ ] Add a database-backed store with atomic single-use consumption and expiry cleanup.
+- [ ] Replace global OAuth cookies with opaque transaction pointers that support concurrent flows.
+- [ ] Add compatibility adapters for all current providers.
+- [ ] Test same-provider and cross-provider multi-tab flows, expiry, mismatch, replay, and double callback.
+
+## Phase 2: Outcomes and Accounts
+
+- [ ] Change account resolution to return `created | linked | returning` with the user.
+- [ ] Add a server-only completion hook with a redacted payload.
+- [ ] Add an additive `oauth_accounts` migration keyed by provider and subject.
+- [ ] Migrate conventional provider lookup to the generic account table while retaining compatibility columns during the deprecation window.
+- [ ] Test creation, explicit linking, returning login, duplicate subject, and email-collision behavior.
+
+## Phase 3: External Adapters
+
+- [ ] Define and export the `OAuthAdapter` start/callback/revoke contract.
+- [ ] Add configurable adapter registration without widening a fixed provider union.
+- [ ] Route adapter success through existing session cookies and optional JWT issuance.
+- [ ] Define stable error categories without exposing provider responses, codes, or credentials.
+- [ ] Publish API documentation and a minimal example adapter before merge.
+
+## Phase 4: Discovery, DPoP, and PAR
+
+- [ ] Define a remote discovery client with mandatory safety-policy hooks.
+- [ ] Define per-transaction and per-upstream-session DPoP key/nonce lifecycle interfaces.
+- [ ] Allow adapters to persist PAR `request_uri` and related metadata in transactions.
+- [ ] Add nonce rotation, retry, proof uniqueness, key deletion, and redaction tests.
+- [ ] Add malicious discovery fixtures covering redirects, private addresses, rebinding, ports, schemes, timeouts, and oversized responses.
+
+## Phase 5: Upstream Credential Lifecycle
+
+- [ ] Define an encrypted upstream credential sink with no browser-facing read method.
+- [ ] Define a refresh lock manager and serialized refresh helper.
+- [ ] Define disconnect behavior separately from ClearAuth session revocation.
+- [ ] Call adapter revocation when supported and make local credential deletion idempotent.
+- [ ] Test concurrent refresh, rotation, revoked grants, partial provider failure, and retry safety.
+
+## Phase 6: Ohok AT Protocol Adapter
+
+- [ ] Implement handle to DID, DID to PDS, and PDS to authorization-server discovery in the adapter.
+- [ ] Enforce Ohok's SSRF and PDS compatibility policy through the library discovery interface.
+- [ ] Publish AT Protocol client metadata from Ohok's HTTPS application route.
+- [ ] Implement PKCE, PAR, DPoP, issuer/sub/PDS binding, token refresh, and disconnect behavior.
+- [ ] Run protocol smoke tests against Bluesky and representative independent PDS implementations.
+
+## Mandatory Gates
+
+- [ ] No transaction-path dependence on raw global `oauth_state` or `oauth_code_verifier` cookie names.
+- [ ] Multi-tab and double-callback security tests pass.
+- [ ] Conventional-provider regression suite passes in every phase.
+- [ ] Public extension interfaces and security invariants are documented before implementation merges.
+- [ ] Security audit, adversarial review, pre-push review, smoke decision, and PR review loop complete per `STANDARD_DEV_WORKFLOW.md`.
+

--- a/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -6,7 +6,7 @@
 
 ## Phase 1: Transaction Core
 
-- [ ] Define `OAuthTransaction`, binding, and store interfaces.
+- [ ] Define `OAuthTransaction`, callback-evidence, and atomic `validateAndConsume` store interfaces.
 - [ ] Add a database-backed store with atomic single-use consumption and expiry cleanup.
 - [ ] Replace global OAuth cookies with one provider-and-transaction-namespaced random browser-binding cookie per flow; consume and delete only the callback's matching cookie.
 - [ ] Add compatibility adapters for all current providers.
@@ -58,4 +58,4 @@
 - [ ] Multi-tab and double-callback security tests pass.
 - [ ] Conventional-provider regression suite passes in every phase.
 - [ ] Public extension interfaces and security invariants are documented before implementation merges.
-- [ ] Security audit, adversarial review, pre-push review, smoke decision, and PR review loop complete per `.ai/protocols/STANDARD_DEV_WORKFLOW.md`.
+- [ ] Security audit, adversarial review, pre-push review, smoke decision, and PR review loop complete per the portfolio `STANDARD_DEV_WORKFLOW` supplied by the agent operating environment.

--- a/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -8,7 +8,7 @@
 
 - [ ] Define `OAuthTransaction`, binding, and store interfaces.
 - [ ] Add a database-backed store with atomic single-use consumption and expiry cleanup.
-- [ ] Replace global OAuth cookies with opaque transaction pointers that support concurrent flows.
+- [ ] Replace global OAuth cookies with one provider-and-transaction-namespaced opaque pointer cookie per flow; consume and delete only the callback's matching cookie.
 - [ ] Add compatibility adapters for all current providers.
 - [ ] Test same-provider and cross-provider multi-tab flows, expiry, mismatch, replay, and double callback.
 
@@ -59,4 +59,3 @@
 - [ ] Conventional-provider regression suite passes in every phase.
 - [ ] Public extension interfaces and security invariants are documented before implementation merges.
 - [ ] Security audit, adversarial review, pre-push review, smoke decision, and PR review loop complete per `STANDARD_DEV_WORKFLOW.md`.
-

--- a/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -58,4 +58,4 @@
 - [ ] Multi-tab and double-callback security tests pass.
 - [ ] Conventional-provider regression suite passes in every phase.
 - [ ] Public extension interfaces and security invariants are documented before implementation merges.
-- [ ] Security audit, adversarial review, pre-push review, smoke decision, and PR review loop complete per the portfolio `STANDARD_DEV_WORKFLOW` supplied by the agent operating environment.
+- [ ] Complete these gates in order: security audit, adversarial review, pre-push review, smoke decision, and PR review loop.

--- a/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
+++ b/tasks/tasks-0005-prd-provider-agnostic-oauth-extension-surface.md
@@ -8,7 +8,7 @@
 
 - [ ] Define `OAuthTransaction`, binding, and store interfaces.
 - [ ] Add a database-backed store with atomic single-use consumption and expiry cleanup.
-- [ ] Replace global OAuth cookies with one provider-and-transaction-namespaced opaque pointer cookie per flow; consume and delete only the callback's matching cookie.
+- [ ] Replace global OAuth cookies with one provider-and-transaction-namespaced random browser-binding cookie per flow; consume and delete only the callback's matching cookie.
 - [ ] Add compatibility adapters for all current providers.
 - [ ] Test same-provider and cross-provider multi-tab flows, expiry, mismatch, replay, and double callback.
 
@@ -58,4 +58,4 @@
 - [ ] Multi-tab and double-callback security tests pass.
 - [ ] Conventional-provider regression suite passes in every phase.
 - [ ] Public extension interfaces and security invariants are documented before implementation merges.
-- [ ] Security audit, adversarial review, pre-push review, smoke decision, and PR review loop complete per `STANDARD_DEV_WORKFLOW.md`.
+- [ ] Security audit, adversarial review, pre-push review, smoke decision, and PR review loop complete per `.ai/protocols/STANDARD_DEV_WORKFLOW.md`.


### PR DESCRIPTION
## Summary

- recommend a provider-agnostic OAuth extension surface rather than a hard-coded Bluesky provider
- separate ClearAuth library responsibilities from Ohok's AT Protocol adapter responsibilities
- map all 11 reported gaps to explicit requirements and security gates
- add a six-phase implementation task list incorporating Ohok's follow-up checklist

## Decision

ClearAuth should own atomic OAuth transactions, generic account/session integration, callback outcomes, and provider-neutral lifecycle interfaces. Ohok's adapter should own handle/DID/PDS discovery policy, AT Protocol issuer binding, PAR/DPoP behavior, and application credential-storage policy.

ClearAuth remains an explicit production no-fit for Ohok's AT Protocol OAuth until transaction, external-adapter, and applicable DPoP/PAR phases ship.

## Sources

- Ohok work order `msg-1784149461545-e23oby`
- Ohok follow-up `msg-1784149805359-bytxck`
- official AT Protocol OAuth specification and client implementation guide

## Validation

- `git diff --check`
- Semgrep: 0 findings
- roborev: clean after clarifying the concurrent-flow cookie model
- smoke: `SKIP (DOCS_ONLY)`; no runtime surface changed
