### PR TITLE
docs(auth): update registration response contract

### DIFF
--- a/QUICKSTART_EMAIL_AUTH.md
+++ b/QUICKSTART_EMAIL_AUTH.md
@@ -204,10 +204,12 @@ Response:
     "avatar_url": null,
     "created_at": "2025-01-01T00:00:00.000Z"
   },
-  "sessionId": "session_id",
-  "verificationToken": "token"
+  "sessionId": "session_id"
 }
 ```
+
+Verification tokens are delivered only through the configured email callback or provider,
+not in the public HTTP response.
 
 ### POST /auth/login
 

--- a/docs/EMAIL_PASSWORD_AUTH.md
+++ b/docs/EMAIL_PASSWORD_AUTH.md
@@ -394,10 +394,13 @@ return response
     "avatar_url": null,
     "created_at": "2025-01-01T00:00:00.000Z"
   },
-  "sessionId": "session_id",
-  "verificationToken": "token"
+  "sessionId": "session_id"
 }
 ```
+
+When email verification is required, ClearAuth sends the token through the configured
+`email.sendVerificationEmail` callback or email provider. Verification tokens are never
+included in the public HTTP response.
 
 #### POST /auth/verify-email
 

--- a/docs/EMAIL_PASSWORD_AUTH.md
+++ b/docs/EMAIL_PASSWORD_AUTH.md
@@ -398,9 +398,9 @@ return response
 }
 ```
 
-When email verification is required, ClearAuth sends the token through the configured
-`email.sendVerificationEmail` callback or email provider. Verification tokens are never
-included in the public HTTP response.
+When email verification is required, ClearAuth attempts delivery through the configured
+`email.sendVerificationEmail` callback or email provider. Delivery failures are logged, but
+registration still succeeds. Verification tokens are never included in the public HTTP response.
 
 #### POST /auth/verify-email
 


### PR DESCRIPTION
## Summary

- remove the verification token from the documented public registration response
- document that delivery is attempted through the configured callback/provider
- clarify that delivery failures are logged while registration still succeeds

## Dependency

Stacked on #34. This documentation describes the response contract introduced by that security patch and must merge after it.

## Validation

- `git diff --check`
- Semgrep: 0 findings
- roborev: clean after clarifying delivery failure behavior
- smoke: `SKIP (DOCS_ONLY)`
