### PR TITLE
feat(oauth): add transaction-bound callback security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Transaction-bound OAuth callbacks** (Codex, 2026-07-15)
+  - **Context:** [PRD 0005](tasks/0005-prd-provider-agnostic-oauth-extension-surface.md) | Phase 1
+  - OAuth callbacks now use server-side, one-time transactions with provider, redirect URI, issuer, adapter-metadata, expiry, state, and browser-binding validation. Conventional providers no longer use shared `oauth_state` or `oauth_code_verifier` cookies.
+  - Apply migration `009_create_oauth_transactions.sql` before deployment; see `docs/OAUTH_TRANSACTION_DEPLOYMENT.md` for the intentional fail-closed transition guidance.
+
 ## [0.7.2] - 2026-07-15
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Transaction-bound OAuth callbacks** (Codex, 2026-07-15)
   - **Context:** [PRD 0005](tasks/0005-prd-provider-agnostic-oauth-extension-surface.md) | Phase 1
   - OAuth callbacks now use server-side, one-time transactions with provider, redirect URI, issuer, adapter-metadata, expiry, state, and browser-binding validation. Conventional providers no longer use shared `oauth_state` or `oauth_code_verifier` cookies.
-  - Apply migration `009_create_oauth_transactions.sql` before deployment; see `docs/OAUTH_TRANSACTION_DEPLOYMENT.md` for the intentional fail-closed transition guidance.
+  - Apply migrations `009_create_oauth_transactions.sql` and `010_harden_oauth_transaction_metadata.sql` before deployment; see `docs/OAUTH_TRANSACTION_DEPLOYMENT.md` for the intentional fail-closed transition guidance.
 
 ## [0.7.2] - 2026-07-15
 

--- a/docs/OAUTH_TRANSACTION_DEPLOYMENT.md
+++ b/docs/OAUTH_TRANSACTION_DEPLOYMENT.md
@@ -9,3 +9,5 @@ Apply `migrations/009_create_oauth_transactions.sql` and `migrations/010_harden_
 Phase 1 deliberately rejects callbacks that rely on the retired global `oauth_state` or `oauth_code_verifier` cookies. An OAuth flow that began before this deployment cannot be bound to a server-side transaction and fails closed with a generic callback error. Users must restart the OAuth login after deployment.
 
 New flows set a short-lived, HttpOnly, provider-and-transaction-specific browser-binding cookie. Multiple tabs and providers can run independently; completing a callback deletes only its matching cookie.
+
+Conventional providers do not currently supply issuer or adapter metadata, so their transactions intentionally bind those fields to `NULL`. The stored fields and atomic predicates are extension scaffolding; issuer and adapter-metadata enforcement begins only when Phase 3 external adapters supply both expected and returned values.

--- a/docs/OAUTH_TRANSACTION_DEPLOYMENT.md
+++ b/docs/OAUTH_TRANSACTION_DEPLOYMENT.md
@@ -1,0 +1,11 @@
+# OAuth Transaction Deployment
+
+## Prerequisite
+
+Apply `migrations/009_create_oauth_transactions.sql` before deploying the Phase 1 OAuth transaction code. The application needs the `oauth_transactions` table for every OAuth login and callback. Use `migrations/rollback_009.sql` only to roll back the application deployment; it permanently removes unfinished transaction records.
+
+## Release Transition
+
+Phase 1 deliberately rejects callbacks that rely on the retired global `oauth_state` or `oauth_code_verifier` cookies. An OAuth flow that began before this deployment cannot be bound to a server-side transaction and fails closed with a generic callback error. Users must restart the OAuth login after deployment.
+
+New flows set a short-lived, HttpOnly, provider-and-transaction-specific browser-binding cookie. Multiple tabs and providers can run independently; completing a callback deletes only its matching cookie.

--- a/docs/OAUTH_TRANSACTION_DEPLOYMENT.md
+++ b/docs/OAUTH_TRANSACTION_DEPLOYMENT.md
@@ -11,3 +11,7 @@ Phase 1 deliberately rejects callbacks that rely on the retired global `oauth_st
 New flows set a short-lived, HttpOnly, provider-and-transaction-specific browser-binding cookie. Multiple tabs and providers can run independently; completing a callback deletes only its matching cookie.
 
 Conventional providers do not currently supply issuer or adapter metadata, so their transactions intentionally bind those fields to `NULL`. The stored fields and atomic predicates are extension scaffolding; issuer and adapter-metadata enforcement begins only when Phase 3 external adapters supply both expected and returned values.
+
+## Expiry Cleanup
+
+Transactions expire after ten minutes but are not removed automatically by request handling. Schedule `createOAuthTransactionStore(config.database).cleanupExpired()` as a periodic server-side maintenance task. Rate-limit the OAuth login route at the consuming application or edge in the same way as other unauthenticated authentication entry points.

--- a/docs/OAUTH_TRANSACTION_DEPLOYMENT.md
+++ b/docs/OAUTH_TRANSACTION_DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 ## Prerequisite
 
-Apply `migrations/009_create_oauth_transactions.sql` before deploying the Phase 1 OAuth transaction code. The application needs the `oauth_transactions` table for every OAuth login and callback. Use `migrations/rollback_009.sql` only to roll back the application deployment; it permanently removes unfinished transaction records.
+Apply `migrations/009_create_oauth_transactions.sql` and `migrations/010_harden_oauth_transaction_metadata.sql`, in order, before deploying the Phase 1 OAuth transaction code. The application needs the `oauth_transactions` table for every OAuth login and callback. Migration 010 is a safe no-op for new installations and converts an early preview schema without requiring an operator to rewrite an applied migration. Use `migrations/rollback_009.sql` only to roll back the application deployment; it permanently removes unfinished transaction records.
 
 ## Release Transition
 

--- a/migrations/009_create_oauth_transactions.sql
+++ b/migrations/009_create_oauth_transactions.sql
@@ -1,0 +1,21 @@
+-- Migration: Create OAuth transactions table
+-- Description: Server-side, one-time OAuth callback transactions
+
+CREATE TABLE IF NOT EXISTS oauth_transactions (
+  id VARCHAR(64) PRIMARY KEY,
+  provider_key VARCHAR(64) NOT NULL,
+  state_hash CHAR(64) NOT NULL,
+  code_verifier TEXT,
+  redirect_uri TEXT NOT NULL,
+  expected_issuer TEXT,
+  adapter_metadata TEXT,
+  browser_binding_hash CHAR(64) NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_transactions_expires_at ON oauth_transactions(expires_at);
+
+COMMENT ON TABLE oauth_transactions IS 'One-time server-side OAuth transactions. State and browser-binding values are stored only as hashes.';
+COMMENT ON COLUMN oauth_transactions.code_verifier IS 'Server-side PKCE verifier. Never expose through a browser-facing API.';

--- a/migrations/009_create_oauth_transactions.sql
+++ b/migrations/009_create_oauth_transactions.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS oauth_transactions (
   code_verifier TEXT,
   redirect_uri TEXT NOT NULL,
   expected_issuer TEXT,
-  adapter_metadata TEXT,
+  adapter_metadata_hash CHAR(64),
   browser_binding_hash CHAR(64) NOT NULL,
   expires_at TIMESTAMPTZ NOT NULL,
   consumed_at TIMESTAMPTZ,
@@ -19,3 +19,4 @@ CREATE INDEX IF NOT EXISTS idx_oauth_transactions_expires_at ON oauth_transactio
 
 COMMENT ON TABLE oauth_transactions IS 'One-time server-side OAuth transactions. State and browser-binding values are stored only as hashes.';
 COMMENT ON COLUMN oauth_transactions.code_verifier IS 'Server-side PKCE verifier. Never expose through a browser-facing API.';
+COMMENT ON COLUMN oauth_transactions.adapter_metadata_hash IS 'Hash of opaque adapter callback metadata; raw metadata is never persisted in this table.';

--- a/migrations/010_harden_oauth_transaction_metadata.sql
+++ b/migrations/010_harden_oauth_transaction_metadata.sql
@@ -1,0 +1,11 @@
+-- Migration: Harden OAuth transaction adapter metadata storage
+-- Description: Forward migration for installations that applied an early 009 preview.
+
+ALTER TABLE oauth_transactions
+  ADD COLUMN IF NOT EXISTS adapter_metadata_hash CHAR(64);
+
+-- Raw adapter metadata must not remain in the transaction table.
+ALTER TABLE oauth_transactions
+  DROP COLUMN IF EXISTS adapter_metadata;
+
+COMMENT ON COLUMN oauth_transactions.adapter_metadata_hash IS 'Hash of opaque adapter callback metadata; raw metadata is never persisted in this table.';

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -14,6 +14,7 @@ The mech-auth project uses PostgreSQL via the Mech Storage HTTP API. Since we do
 | `002_create_sessions_table.sql` | Session management with expiration tracking | `rollback_002.sql` |
 | `003_create_verification_tokens.sql` | Email verification tokens | `rollback_003.sql` |
 | `004_create_reset_tokens.sql` | Password reset tokens | `rollback_004.sql` |
+| `009_create_oauth_transactions.sql` | One-time OAuth callback transactions | `rollback_009.sql` |
 
 ## Prerequisites
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -16,7 +16,6 @@ The mech-auth project uses PostgreSQL via the Mech Storage HTTP API. Since we do
 | `004_create_reset_tokens.sql` | Password reset tokens | `rollback_004.sql` |
 | `009_create_oauth_transactions.sql` | Server-side OAuth callback transactions | `rollback_009.sql` |
 | `010_harden_oauth_transaction_metadata.sql` | Forward compatibility for early OAuth transaction previews | `rollback_010.sql` |
-| `009_create_oauth_transactions.sql` | One-time OAuth callback transactions | `rollback_009.sql` |
 
 ## Prerequisites
 
@@ -46,6 +45,8 @@ psql $DATABASE_URL -f migrations/001_create_users_table.sql
 psql $DATABASE_URL -f migrations/002_create_sessions_table.sql
 psql $DATABASE_URL -f migrations/003_create_verification_tokens.sql
 psql $DATABASE_URL -f migrations/004_create_reset_tokens.sql
+psql $DATABASE_URL -f migrations/009_create_oauth_transactions.sql
+psql $DATABASE_URL -f migrations/010_harden_oauth_transaction_metadata.sql
 ```
 
 ### Option 2: Using Interactive psql
@@ -59,6 +60,8 @@ psql $DATABASE_URL
 \i migrations/002_create_sessions_table.sql
 \i migrations/003_create_verification_tokens.sql
 \i migrations/004_create_reset_tokens.sql
+\i migrations/009_create_oauth_transactions.sql
+\i migrations/010_harden_oauth_transaction_metadata.sql
 
 # Exit
 \q
@@ -79,6 +82,8 @@ To rollback migrations (in reverse order):
 
 ```bash
 # Rollback in reverse order
+psql $DATABASE_URL -f migrations/rollback_010.sql
+psql $DATABASE_URL -f migrations/rollback_009.sql
 psql $DATABASE_URL -f migrations/rollback_004.sql
 psql $DATABASE_URL -f migrations/rollback_003.sql
 psql $DATABASE_URL -f migrations/rollback_002.sql
@@ -103,6 +108,7 @@ psql $DATABASE_URL
 \d sessions
 \d email_verification_tokens
 \d password_reset_tokens
+\d oauth_transactions
 
 # List all indexes
 \di

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -14,6 +14,8 @@ The mech-auth project uses PostgreSQL via the Mech Storage HTTP API. Since we do
 | `002_create_sessions_table.sql` | Session management with expiration tracking | `rollback_002.sql` |
 | `003_create_verification_tokens.sql` | Email verification tokens | `rollback_003.sql` |
 | `004_create_reset_tokens.sql` | Password reset tokens | `rollback_004.sql` |
+| `009_create_oauth_transactions.sql` | Server-side OAuth callback transactions | `rollback_009.sql` |
+| `010_harden_oauth_transaction_metadata.sql` | Forward compatibility for early OAuth transaction previews | `rollback_010.sql` |
 | `009_create_oauth_transactions.sql` | One-time OAuth callback transactions | `rollback_009.sql` |
 
 ## Prerequisites

--- a/migrations/rollback_009.sql
+++ b/migrations/rollback_009.sql
@@ -1,0 +1,2 @@
+-- Rollback: Remove OAuth transactions table
+DROP TABLE IF EXISTS oauth_transactions;

--- a/migrations/rollback_010.sql
+++ b/migrations/rollback_010.sql
@@ -1,0 +1,3 @@
+-- Rollback: Remove hardened OAuth transaction metadata hash
+ALTER TABLE oauth_transactions
+  DROP COLUMN IF EXISTS adapter_metadata_hash;

--- a/src/__tests__/jwt-integration.test.ts
+++ b/src/__tests__/jwt-integration.test.ts
@@ -865,7 +865,7 @@ describe("JWT Integration: OAuth callback with jwt config issues JWT cookies", (
       validateAuthorizationCode: vi.fn().mockResolvedValue({
         accessToken: () => "github-access-token",
       }),
-      createAuthorizationURL: vi.fn(),
+      createAuthorizationURL: vi.fn().mockReturnValue(new URL("https://github.com/login/oauth/authorize?state=provider-state")),
     }
     vi.spyOn(arcticProviders, "createGitHubProvider").mockReturnValue(mockGitHubProvider as any)
 
@@ -873,6 +873,18 @@ describe("JWT Integration: OAuth callback with jwt config issues JWT cookies", (
     global.fetch = fetchMock as unknown as typeof fetch
 
     fetchMock
+      .mockResolvedValueOnce({
+        // OAuth transaction INSERT
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, rows: [{ id: "transaction-id" }], rowCount: 1 }),
+      })
+      .mockResolvedValueOnce({
+        // Atomic OAuth transaction consume
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, rows: [{ code_verifier: null }], rowCount: 1 }),
+      })
       .mockResolvedValueOnce({
         // GitHub user API (fetchGitHubUserProfile)
         ok: true,
@@ -945,14 +957,19 @@ describe("JWT Integration: OAuth callback with jwt config issues JWT cookies", (
         }),
       })
 
-    // The callback needs a matching state cookie
-    const state = "test-oauth-state-12345"
+    // Start the flow to create its server-side transaction and matching binding cookie.
+    const start = await handleClearAuthRequest(
+      new Request("https://example.com/auth/oauth/github", { method: "GET" }),
+      config,
+    )
+    const state = new URL(start.headers.get("Location")!).searchParams.get("state")!
+    const bindingCookie = start.headers.get("Set-Cookie")!.split(";")[0]
     const req = new Request(
       `https://example.com/auth/callback/github?code=github-code&state=${state}`,
       {
         method: "GET",
         headers: {
-          Cookie: `oauth_state=${state}`,
+          Cookie: bindingCookie,
         },
       }
     )

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -157,6 +157,21 @@ export interface ChallengesTable {
   expires_at: Date // Challenges expire after 10 minutes
 }
 
+/** One-time OAuth callback transactions. Secrets are hashed except for the server-only PKCE verifier. */
+export interface OAuthTransactionsTable {
+  id: string
+  provider_key: string
+  state_hash: string
+  code_verifier: string | null
+  redirect_uri: string
+  expected_issuer: string | null
+  adapter_metadata: string | null
+  browser_binding_hash: string
+  expires_at: Date
+  consumed_at: Date | null
+  created_at: ColumnType<Date, Date | undefined, never>
+}
+
 /**
  * Database Schema
  *
@@ -171,6 +186,7 @@ export interface Database {
   refresh_tokens: RefreshTokensTable
   devices: DevicesTable
   challenges: ChallengesTable
+  oauth_transactions: OAuthTransactionsTable
 }
 
 /**
@@ -184,6 +200,7 @@ export type MagicLinkToken = Selectable<MagicLinkTokensTable>
 export type RefreshToken = Selectable<RefreshTokensTable>
 export type Device = Selectable<DevicesTable>
 export type Challenge = Selectable<ChallengesTable>
+export type OAuthTransaction = Selectable<OAuthTransactionsTable>
 
 /**
  * Type-safe input types for INSERT queries
@@ -196,6 +213,7 @@ export type NewMagicLinkToken = Insertable<MagicLinkTokensTable>
 export type NewRefreshToken = Insertable<RefreshTokensTable>
 export type NewDevice = Insertable<DevicesTable>
 export type NewChallenge = Insertable<ChallengesTable>
+export type NewOAuthTransaction = Insertable<OAuthTransactionsTable>
 
 /**
  * Type-safe input types for UPDATE queries
@@ -208,6 +226,7 @@ export type MagicLinkTokenUpdate = Updateable<MagicLinkTokensTable>
 export type RefreshTokenUpdate = Updateable<RefreshTokensTable>
 export type DeviceUpdate = Updateable<DevicesTable>
 export type ChallengeUpdate = Updateable<ChallengesTable>
+export type OAuthTransactionUpdate = Updateable<OAuthTransactionsTable>
 
 /**
  * User with session information (common join result)

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -165,7 +165,7 @@ export interface OAuthTransactionsTable {
   code_verifier: string | null
   redirect_uri: string
   expected_issuer: string | null
-  adapter_metadata: string | null
+  adapter_metadata_hash: string | null
   browser_binding_hash: string
   expires_at: Date
   consumed_at: Date | null

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -12,6 +12,8 @@
  * @see /migrations/006_create_refresh_tokens.sql
  * @see /migrations/007_create_devices_table.sql
  * @see /migrations/008_create_challenges_table.sql
+ * @see /migrations/009_create_oauth_transactions.sql
+ * @see /migrations/010_harden_oauth_transaction_metadata.sql
  */
 
 import type { ColumnType, Selectable, Insertable, Updateable } from 'kysely'

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export * from "./oauth/apple.js"
 export * from "./oauth/microsoft.js"
 export * from "./oauth/linkedin.js"
 export * from "./oauth/meta.js"
+export * from "./oauth/transactions.js"
 
 // Email/Password authentication
 export * from "./auth/utils.js"

--- a/src/oauth/__tests__/handler-transactions.test.ts
+++ b/src/oauth/__tests__/handler-transactions.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest'
+import { handleOAuthRequest } from '../handler.js'
+import { getOAuthTransactionCookieName, parseOAuthTransactionState } from '../transactions.js'
+
+function oauthConfig(database: any) {
+  return {
+    database,
+    secret: 'test-secret',
+    baseUrl: 'https://app.example.com',
+    isProduction: false,
+    oauth: {
+      github: {
+        clientId: 'github-client',
+        clientSecret: 'github-secret',
+        redirectUri: 'https://app.example.com/auth/callback/github',
+      },
+      google: {
+        clientId: 'google-client',
+        clientSecret: 'google-secret',
+        redirectUri: 'https://app.example.com/auth/callback/google',
+      },
+    },
+  }
+}
+
+function transactionInsertDb() {
+  const transactions: any[] = []
+  return {
+    transactions,
+    insertInto: vi.fn(() => ({
+      values: (value: any) => ({
+        returningAll: () => ({
+          executeTakeFirstOrThrow: async () => {
+            const row = { ...value, created_at: new Date() }
+            transactions.push(row)
+            return row
+          },
+        }),
+      }),
+    })),
+  }
+}
+
+function successfulCallbackDb(transaction: any) {
+  const query: any = {
+    set: () => query,
+    where: () => query,
+    returningAll: () => ({ executeTakeFirst: async () => transaction }),
+  }
+  const user = {
+    id: 'user-1', email: 'person@example.com', email_verified: true, password_hash: null,
+    github_id: '123', google_id: null, discord_id: null, apple_id: null, microsoft_id: null, linkedin_id: null, meta_id: null,
+    name: 'Person', avatar_url: null, created_at: new Date(), updated_at: new Date(),
+  }
+  const noRows = { selectAll: () => noRows, where: () => noRows, executeTakeFirst: async () => undefined }
+  return {
+    updateTable: vi.fn(() => query),
+    selectFrom: vi.fn(() => noRows),
+    insertInto: vi.fn((table: string) => ({
+      values: () => table === 'users'
+        ? { returningAll: () => ({ executeTakeFirstOrThrow: async () => user }) }
+        : { execute: async () => undefined },
+    })),
+  }
+}
+
+describe('OAuth transaction HTTP bridge', () => {
+  it('creates distinct transaction binding cookies for same-provider and cross-provider flows', async () => {
+    const db = transactionInsertDb()
+
+    const first = await handleOAuthRequest(new Request('https://app.example.com/auth/oauth/github'), oauthConfig(db) as any)
+    const second = await handleOAuthRequest(new Request('https://app.example.com/auth/oauth/github'), oauthConfig(db) as any)
+    const google = await handleOAuthRequest(new Request('https://app.example.com/auth/oauth/google'), oauthConfig(db) as any)
+
+    expect(first.status).toBe(302)
+    expect(second.status).toBe(302)
+    expect(google.status).toBe(302)
+    expect(db.transactions).toHaveLength(3)
+    expect(db.transactions[0].state_hash).not.toBe(db.transactions[1].state_hash)
+    expect(db.transactions[0].browser_binding_hash).not.toBe(db.transactions[1].browser_binding_hash)
+
+    const firstState = parseOAuthTransactionState(new URL(first.headers.get('Location')!).searchParams.get('state')!)!
+    const secondState = parseOAuthTransactionState(new URL(second.headers.get('Location')!).searchParams.get('state')!)!
+    const googleState = parseOAuthTransactionState(new URL(google.headers.get('Location')!).searchParams.get('state')!)!
+    expect(first.headers.get('Set-Cookie')).toContain(`${getOAuthTransactionCookieName('github', firstState.id)}=`)
+    expect(second.headers.get('Set-Cookie')).toContain(`${getOAuthTransactionCookieName('github', secondState.id)}=`)
+    expect(google.headers.get('Set-Cookie')).toContain(`${getOAuthTransactionCookieName('google', googleState.id)}=`)
+    expect(google.headers.get('Set-Cookie')).not.toContain(getOAuthTransactionCookieName('github', firstState.id))
+    expect(first.headers.get('Set-Cookie')).not.toContain('oauth_state=')
+    expect(first.headers.get('Set-Cookie')).not.toContain('oauth_code_verifier=')
+  })
+
+  it('fails a binding mismatch before provider token exchange', async () => {
+    const id = 'a'.repeat(32)
+    const state = `${id}.${'b'.repeat(43)}`
+    const where = vi.fn(() => query)
+    const query: any = {
+      set: vi.fn(() => query),
+      where,
+      returningAll: vi.fn(() => ({ executeTakeFirst: async () => undefined })),
+    }
+    const db = { updateTable: vi.fn(() => query) }
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    const response = await handleOAuthRequest(
+      new Request(`https://app.example.com/auth/callback/github?code=code&state=${state}`, {
+        headers: { Cookie: `${getOAuthTransactionCookieName('github', id)}=wrong-binding` },
+      }),
+      oauthConfig(db) as any,
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe('Invalid OAuth callback')
+    expect(db.updateTable).toHaveBeenCalledWith('oauth_transactions')
+    expect(where).toHaveBeenCalledWith('provider_key', '=', 'github')
+    expect(where).toHaveBeenCalledWith('redirect_uri', '=', 'https://app.example.com/auth/callback/github')
+    expect(where).toHaveBeenCalledWith('consumed_at', 'is', null)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    fetchSpy.mockRestore()
+  })
+
+  it('deletes only the consumed transaction cookie and rejects a replay before exchange', async () => {
+    const startDb = transactionInsertDb()
+    const start = await handleOAuthRequest(new Request('https://app.example.com/auth/oauth/github'), oauthConfig(startDb) as any)
+    const state = new URL(start.headers.get('Location')!).searchParams.get('state')!
+    const reference = parseOAuthTransactionState(state)!
+    const transaction = startDb.transactions[0]
+    const db = successfulCallbackDb(transaction)
+    const originalFetch = globalThis.fetch
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'access-token', token_type: 'bearer' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 123, login: 'person', email: 'person@example.com', name: 'Person', avatar_url: null }), { status: 200 }))
+    globalThis.fetch = fetchSpy as typeof fetch
+    const bindingCookie = getOAuthTransactionCookieName('github', reference.id)
+
+    const callback = await handleOAuthRequest(
+      new Request(`https://app.example.com/auth/callback/github?code=code&state=${state}`, { headers: { Cookie: `${bindingCookie}=binding` } }),
+      oauthConfig(db) as any,
+    )
+
+    expect(callback.status).toBe(302)
+    expect(callback.headers.get('Set-Cookie')).toContain(`${bindingCookie}=;`)
+    expect(callback.headers.get('Set-Cookie')).not.toContain('oauth_state=')
+    expect(callback.headers.get('Set-Cookie')).not.toContain('oauth_code_verifier=')
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+
+    const replayQuery: any = {
+      set: () => replayQuery,
+      where: () => replayQuery,
+      returningAll: () => ({ executeTakeFirst: async () => undefined }),
+    }
+    ;(db.updateTable as any).mockImplementation(() => replayQuery)
+    fetchSpy.mockClear()
+    const replay = await handleOAuthRequest(
+      new Request(`https://app.example.com/auth/callback/github?code=code&state=${state}`, { headers: { Cookie: `${bindingCookie}=binding` } }),
+      oauthConfig(db) as any,
+    )
+    expect(replay.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    globalThis.fetch = originalFetch
+  })
+})

--- a/src/oauth/__tests__/handler-transactions.test.ts
+++ b/src/oauth/__tests__/handler-transactions.test.ts
@@ -169,4 +169,24 @@ describe('OAuth transaction HTTP bridge', () => {
     expect(fetchSpy).not.toHaveBeenCalled()
     globalThis.fetch = originalFetch
   })
+
+  it('clears the consumed transaction cookie when token exchange fails', async () => {
+    const startDb = transactionInsertDb()
+    const start = await handleOAuthRequest(new Request('https://app.example.com/auth/oauth/github'), oauthConfig(startDb) as any)
+    const state = new URL(start.headers.get('Location')!).searchParams.get('state')!
+    const reference = parseOAuthTransactionState(state)!
+    const db = successfulCallbackDb(startDb.transactions[0])
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error('provider unavailable')) as typeof fetch
+    const bindingCookie = getOAuthTransactionCookieName('github', reference.id)
+
+    const callback = await handleOAuthRequest(
+      new Request(`https://app.example.com/auth/callback/github?code=code&state=${state}`, { headers: { Cookie: `${bindingCookie}=binding` } }),
+      oauthConfig(db) as any,
+    )
+
+    expect(callback.status).toBe(400)
+    expect(callback.headers.get('Set-Cookie')).toContain(`${bindingCookie}=;`)
+    globalThis.fetch = originalFetch
+  })
 })

--- a/src/oauth/__tests__/handler-transactions.test.ts
+++ b/src/oauth/__tests__/handler-transactions.test.ts
@@ -119,6 +119,16 @@ describe('OAuth transaction HTTP bridge', () => {
     fetchSpy.mockRestore()
   })
 
+  it('does not reflect provider authorization error details', async () => {
+    const response = await handleOAuthRequest(
+      new Request('https://app.example.com/auth/callback/github?error=access_denied&error_description=private-provider-detail'),
+      oauthConfig({}) as any,
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe('OAuth authorization was denied')
+  })
+
   it('deletes only the consumed transaction cookie and rejects a replay before exchange', async () => {
     const startDb = transactionInsertDb()
     const start = await handleOAuthRequest(new Request('https://app.example.com/auth/oauth/github'), oauthConfig(startDb) as any)

--- a/src/oauth/__tests__/transactions.test.ts
+++ b/src/oauth/__tests__/transactions.test.ts
@@ -43,6 +43,7 @@ describe('OAuth transaction core', () => {
     const prepared = await createOAuthTransaction({
       providerKey: 'github',
       redirectUri: 'https://app.example.com/auth/callback/github',
+      adapterMetadata: 'adapter-callback-binding',
     })
     const whereCalls: unknown[][] = []
     const row = { ...prepared.transaction, created_at: new Date(), consumed_at: new Date() }
@@ -64,6 +65,7 @@ describe('OAuth transaction core', () => {
       providerKey: 'github',
       redirectUri: 'https://app.example.com/auth/callback/github',
       browserBindingSecret: prepared.browserBindingSecret,
+      adapterMetadata: 'adapter-callback-binding',
       now: new Date(),
     })
 
@@ -72,10 +74,78 @@ describe('OAuth transaction core', () => {
     expect(whereCalls).toContainEqual(['provider_key', '=', 'github'])
     expect(whereCalls).toContainEqual(['redirect_uri', '=', 'https://app.example.com/auth/callback/github'])
     expect(whereCalls).toContainEqual(['expected_issuer', 'is', null])
+    expect(whereCalls.some(([column]) => column === 'adapter_metadata_hash')).toBe(true)
     expect(whereCalls).toContainEqual(['expires_at', '>', expect.any(Date)])
     expect(whereCalls).toContainEqual(['consumed_at', 'is', null])
     expect(whereCalls.some(([column]) => column === 'state_hash')).toBe(true)
     expect(whereCalls.some(([column]) => column === 'browser_binding_hash')).toBe(true)
     expect(whereCalls.flat()).not.toContain(prepared.browserBindingSecret)
+    expect(whereCalls.flat()).not.toContain('adapter-callback-binding')
+  })
+
+  it('rejects expired, issuer, redirect, metadata, and replayed callback evidence', async () => {
+    const createStore = async (input: Parameters<typeof createOAuthTransaction>[0]) => {
+      const prepared = await createOAuthTransaction(input)
+      let row: any = { ...prepared.transaction, created_at: new Date() }
+      const db = {
+        updateTable: () => {
+          const whereCalls: unknown[][] = []
+          let consumedAt: Date | undefined
+          const query: any = {
+            set: (value: { consumed_at: Date }) => {
+              consumedAt = value.consumed_at
+              return query
+            },
+            where: (...args: unknown[]) => {
+              whereCalls.push(args)
+              return query
+            },
+            returningAll: () => ({
+              executeTakeFirst: async () => {
+                const matches = whereCalls.every(([column, operator, value]) => {
+                  if (column === 'expires_at' && operator === '>') return row.expires_at > value
+                  if (column === 'consumed_at' && operator === 'is') return row.consumed_at === value
+                  return row[column] === value
+                })
+                if (!matches) return undefined
+                row = { ...row, consumed_at: consumedAt }
+                return row
+              },
+            }),
+          }
+          return query
+        },
+      }
+      return { prepared, store: createOAuthTransactionStore(db as any) }
+    }
+
+    const now = new Date('2026-07-15T12:00:00Z')
+    const validInput = {
+      providerKey: 'github', redirectUri: 'https://app.example.com/auth/callback/github',
+      expectedIssuer: 'https://issuer.example.com', adapterMetadata: 'metadata', expiresAt: new Date(now.getTime() + 60_000),
+    }
+    const evidence = (prepared: Awaited<ReturnType<typeof createOAuthTransaction>>) => ({
+      returnedState: prepared.state, providerKey: 'github', redirectUri: validInput.redirectUri,
+      returnedIssuer: validInput.expectedIssuer, adapterMetadata: 'metadata', browserBindingSecret: prepared.browserBindingSecret, now,
+    })
+
+    const expired = await createStore({ ...validInput, expiresAt: new Date(now.getTime() - 1) })
+    expect(await expired.store.validateAndConsume(expired.prepared.id, evidence(expired.prepared))).toBeNull()
+
+    const issuer = await createStore(validInput)
+    expect(await issuer.store.validateAndConsume(issuer.prepared.id, { ...evidence(issuer.prepared), returnedIssuer: 'https://other.example.com' })).toBeNull()
+
+    const redirect = await createStore(validInput)
+    expect(await redirect.store.validateAndConsume(redirect.prepared.id, { ...evidence(redirect.prepared), redirectUri: 'https://attacker.example.com/callback' })).toBeNull()
+
+    const metadata = await createStore(validInput)
+    expect(await metadata.store.validateAndConsume(metadata.prepared.id, { ...evidence(metadata.prepared), adapterMetadata: 'modified' })).toBeNull()
+
+    const replay = await createStore(validInput)
+    const [first, second] = await Promise.all([
+      replay.store.validateAndConsume(replay.prepared.id, evidence(replay.prepared)),
+      replay.store.validateAndConsume(replay.prepared.id, evidence(replay.prepared)),
+    ])
+    expect([first, second].filter(Boolean)).toHaveLength(1)
   })
 })

--- a/src/oauth/__tests__/transactions.test.ts
+++ b/src/oauth/__tests__/transactions.test.ts
@@ -43,6 +43,7 @@ describe('OAuth transaction core', () => {
     const prepared = await createOAuthTransaction({
       providerKey: 'github',
       redirectUri: 'https://app.example.com/auth/callback/github',
+      expectedIssuer: 'https://issuer.example.com',
       adapterMetadata: 'adapter-callback-binding',
     })
     const whereCalls: unknown[][] = []
@@ -64,6 +65,7 @@ describe('OAuth transaction core', () => {
       returnedState: prepared.state,
       providerKey: 'github',
       redirectUri: 'https://app.example.com/auth/callback/github',
+      returnedIssuer: 'https://issuer.example.com',
       browserBindingSecret: prepared.browserBindingSecret,
       adapterMetadata: 'adapter-callback-binding',
       now: new Date(),
@@ -73,8 +75,8 @@ describe('OAuth transaction core', () => {
     expect(whereCalls).toContainEqual(['id', '=', prepared.id])
     expect(whereCalls).toContainEqual(['provider_key', '=', 'github'])
     expect(whereCalls).toContainEqual(['redirect_uri', '=', 'https://app.example.com/auth/callback/github'])
-    expect(whereCalls).toContainEqual(['expected_issuer', 'is', null])
-    expect(whereCalls.some(([column]) => column === 'adapter_metadata_hash')).toBe(true)
+    expect(whereCalls).toContainEqual(['expected_issuer', '=', 'https://issuer.example.com'])
+    expect(whereCalls.some(([column, operator]) => column === 'adapter_metadata_hash' && operator === '=')).toBe(true)
     expect(whereCalls).toContainEqual(['expires_at', '>', expect.any(Date)])
     expect(whereCalls).toContainEqual(['consumed_at', 'is', null])
     expect(whereCalls.some(([column]) => column === 'state_hash')).toBe(true)

--- a/src/oauth/__tests__/transactions.test.ts
+++ b/src/oauth/__tests__/transactions.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createOAuthTransaction,
+  createOAuthTransactionStore,
+  getOAuthTransactionCookieName,
+  parseOAuthTransactionState,
+} from '../transactions.js'
+
+describe('OAuth transaction core', () => {
+  it('creates independent, provider-namespaced browser bindings for concurrent flows', async () => {
+    const first = await createOAuthTransaction({
+      providerKey: 'github',
+      redirectUri: 'https://app.example.com/auth/callback/github',
+    })
+    const second = await createOAuthTransaction({
+      providerKey: 'github',
+      redirectUri: 'https://app.example.com/auth/callback/github',
+    })
+    const google = await createOAuthTransaction({
+      providerKey: 'google',
+      redirectUri: 'https://app.example.com/auth/callback/google',
+      codeVerifier: 'pkce-verifier',
+    })
+
+    expect(first.id).not.toBe(second.id)
+    expect(first.state).not.toBe(second.state)
+    expect(first.browserBindingSecret).not.toBe(second.browserBindingSecret)
+    expect(getOAuthTransactionCookieName('github', first.id)).not.toBe(getOAuthTransactionCookieName('github', second.id))
+    expect(getOAuthTransactionCookieName('github', first.id)).not.toBe(getOAuthTransactionCookieName('google', google.id))
+    expect(parseOAuthTransactionState(first.state)).toEqual({ id: first.id, state: first.state })
+    expect(google.codeVerifier).toBe('pkce-verifier')
+  })
+
+  it('rejects malformed transaction state before cookie lookup', () => {
+    expect(parseOAuthTransactionState('')).toBeNull()
+    expect(parseOAuthTransactionState('only-an-id')).toBeNull()
+    expect(parseOAuthTransactionState('.missing-id')).toBeNull()
+    expect(parseOAuthTransactionState('id.')).toBeNull()
+    expect(parseOAuthTransactionState('bad.id.extra')).toBeNull()
+  })
+
+  it('uses one conditional update containing every callback invariant', async () => {
+    const prepared = await createOAuthTransaction({
+      providerKey: 'github',
+      redirectUri: 'https://app.example.com/auth/callback/github',
+    })
+    const whereCalls: unknown[][] = []
+    const row = { ...prepared.transaction, created_at: new Date(), consumed_at: new Date() }
+    const query: any = {
+      set: () => query,
+      where: (...args: unknown[]) => {
+        whereCalls.push(args)
+        return query
+      },
+      returningAll: () => ({ executeTakeFirst: async () => row }),
+    }
+    const db = { updateTable: (...args: unknown[]) => {
+      expect(args).toEqual(['oauth_transactions'])
+      return query
+    } }
+
+    const consumed = await createOAuthTransactionStore(db as any).validateAndConsume(prepared.id, {
+      returnedState: prepared.state,
+      providerKey: 'github',
+      redirectUri: 'https://app.example.com/auth/callback/github',
+      browserBindingSecret: prepared.browserBindingSecret,
+      now: new Date(),
+    })
+
+    expect(consumed).toEqual(row)
+    expect(whereCalls).toContainEqual(['id', '=', prepared.id])
+    expect(whereCalls).toContainEqual(['provider_key', '=', 'github'])
+    expect(whereCalls).toContainEqual(['redirect_uri', '=', 'https://app.example.com/auth/callback/github'])
+    expect(whereCalls).toContainEqual(['expected_issuer', 'is', null])
+    expect(whereCalls).toContainEqual(['expires_at', '>', expect.any(Date)])
+    expect(whereCalls).toContainEqual(['consumed_at', 'is', null])
+    expect(whereCalls.some(([column]) => column === 'state_hash')).toBe(true)
+    expect(whereCalls.some(([column]) => column === 'browser_binding_hash')).toBe(true)
+    expect(whereCalls.flat()).not.toContain(prepared.browserBindingSecret)
+  })
+})

--- a/src/oauth/handler.ts
+++ b/src/oauth/handler.ts
@@ -26,6 +26,7 @@ import {
   createOAuthTransaction,
   createOAuthTransactionStore,
   getOAuthTransactionCookieName,
+  OAUTH_TRANSACTION_TTL_SECONDS,
   parseOAuthTransactionState,
 } from './transactions.js'
 
@@ -77,7 +78,7 @@ async function handleOAuthLogin(
       secure: config.isProduction ?? true,
       sameSite: 'lax',
       path: '/',
-      maxAge: 600, // 10 minutes
+      maxAge: OAUTH_TRANSACTION_TTL_SECONDS,
     })]
 
     const headers = createHeadersWithCookies(cookies, url.toString())
@@ -102,6 +103,7 @@ async function handleOAuthCallbackRequest(
   providerName: string,
   callbackHandler: (config: ClearAuthConfig, code: string, storedState: string, returnedState: string, codeVerifier?: string) => Promise<any>
 ): Promise<Response> {
+  let bindingCookieName: string | undefined
   try {
     const url = new URL(request.url)
     const code = url.searchParams.get('code')
@@ -122,7 +124,7 @@ async function handleOAuthCallbackRequest(
     }
 
     const cookies = parseCookies(request.headers.get('Cookie') || '')
-    const bindingCookieName = getOAuthTransactionCookieName(providerName, stateReference.id)
+    bindingCookieName = getOAuthTransactionCookieName(providerName, stateReference.id)
     const browserBindingSecret = cookies[bindingCookieName]
     if (!browserBindingSecret) {
       return new Response('Invalid OAuth callback', { status: 400 })
@@ -185,7 +187,12 @@ async function handleOAuthCallbackRequest(
     return new Response(null, { status: 302, headers })
   } catch (error) {
     console.error(providerName + ' callback error:', error) // nosemgrep
-    return new Response('OAuth callback failed', { status: 400 })
+    return new Response('OAuth callback failed', {
+      status: 400,
+      headers: bindingCookieName
+        ? createHeadersWithCookies([createDeleteCookieHeader(bindingCookieName, { path: '/' })])
+        : undefined,
+    })
   }
 }
 

--- a/src/oauth/handler.ts
+++ b/src/oauth/handler.ts
@@ -22,6 +22,12 @@ import {
   createCookieHeader,
   createDeleteCookieHeader,
 } from './callbacks.js'
+import {
+  createOAuthTransaction,
+  createOAuthTransactionStore,
+  getOAuthTransactionCookieName,
+  parseOAuthTransactionState,
+} from './transactions.js'
 
 /**
  * Helper to create Headers with multiple Set-Cookie headers
@@ -53,30 +59,26 @@ function createHeadersWithCookies(cookies: string[], location?: string): Headers
  */
 async function handleOAuthLogin(
   config: ClearAuthConfig,
+  providerKey: string,
   providerName: string,
   authUrlGenerator: (config: ClearAuthConfig) => Promise<{ url: URL; state: string; codeVerifier?: string }>
 ): Promise<Response> {
   try {
     const { url, state, codeVerifier } = await authUrlGenerator(config)
+    const redirectUri = getRedirectUri(config, providerKey)
+    const prepared = await createOAuthTransaction({ providerKey, redirectUri, codeVerifier })
+    const store = createOAuthTransactionStore(config.database)
+    await store.create(prepared.transaction)
+    url.searchParams.set('state', prepared.state)
 
-    const cookies: string[] = []
-    cookies.push(createCookieHeader('oauth_state', state, {
+    const cookieName = getOAuthTransactionCookieName(providerKey, prepared.id)
+    const cookies = [createCookieHeader(cookieName, prepared.browserBindingSecret, {
       httpOnly: true,
       secure: config.isProduction ?? true,
       sameSite: 'lax',
       path: '/',
       maxAge: 600, // 10 minutes
-    }))
-
-    if (codeVerifier) {
-      cookies.push(createCookieHeader('oauth_code_verifier', codeVerifier, {
-        httpOnly: true,
-        secure: config.isProduction ?? true,
-        sameSite: 'lax',
-        path: '/',
-        maxAge: 600, // 10 minutes
-      }))
-    }
+    })]
 
     const headers = createHeadersWithCookies(cookies, url.toString())
     return new Response(null, { status: 302, headers })
@@ -114,15 +116,34 @@ async function handleOAuthCallbackRequest(
       return new Response('Missing code or state parameter', { status: 400 })
     }
 
-    const cookies = parseCookies(request.headers.get('Cookie') || '')
-    const storedState = cookies['oauth_state']
-    const codeVerifier = cookies['oauth_code_verifier']
-
-    if (!storedState) {
-      return new Response('Missing state cookie', { status: 400 })
+    const stateReference = parseOAuthTransactionState(returnedState)
+    if (!stateReference) {
+      return new Response('Invalid OAuth state parameter', { status: 400 })
     }
 
-    const result = await callbackHandler(config, code, storedState, returnedState, codeVerifier)
+    const cookies = parseCookies(request.headers.get('Cookie') || '')
+    const bindingCookieName = getOAuthTransactionCookieName(providerName, stateReference.id)
+    const browserBindingSecret = cookies[bindingCookieName]
+    if (!browserBindingSecret) {
+      return new Response('Invalid OAuth callback', { status: 400 })
+    }
+
+    const transaction = await createOAuthTransactionStore(config.database).validateAndConsume(stateReference.id, {
+      returnedState,
+      providerKey: providerName,
+      redirectUri: getRedirectUri(config, providerName),
+      browserBindingSecret,
+      now: new Date(),
+    })
+    if (!transaction) {
+      return new Response('Invalid OAuth callback', {
+        status: 400,
+        headers: createHeadersWithCookies([createDeleteCookieHeader(bindingCookieName, { path: '/' })]),
+      })
+    }
+
+    // Provider callbacks retain their state-equality guard; the transaction store performed the real validation.
+    const result = await callbackHandler(config, code, returnedState, returnedState, transaction.code_verifier ?? undefined)
     const user = await upsertOAuthUser(config.database, providerName as any, result.profile)
     const context = getRequestContext(request)
     const expiresInSeconds = config.session?.expiresIn ?? 2592000 // 30 days
@@ -138,10 +159,7 @@ async function handleOAuthCallbackRequest(
       maxAge: expiresInSeconds,
     })
 
-    const deleteCookies = [createDeleteCookieHeader('oauth_state', { path: '/' })]
-    if (codeVerifier) {
-      deleteCookies.push(createDeleteCookieHeader('oauth_code_verifier', { path: '/' }))
-    }
+    const deleteCookies = [createDeleteCookieHeader(bindingCookieName, { path: '/' })]
 
     const additionalCookies: string[] = []
     if (config.jwt) {
@@ -167,8 +185,7 @@ async function handleOAuthCallbackRequest(
     return new Response(null, { status: 302, headers })
   } catch (error) {
     console.error(providerName + ' callback error:', error) // nosemgrep
-    const message = error instanceof Error ? error.message : 'OAuth callback failed'
-    return new Response(message, { status: 400 })
+    return new Response('OAuth callback failed', { status: 400 })
   }
 }
 
@@ -191,7 +208,7 @@ export async function handleOAuthRequest(
 
   // GitHub
   if (pathname === '/auth/oauth/github' || pathname === '/auth/github/login') {
-    return handleOAuthLogin(config, 'GitHub', generateGitHubAuthUrl)
+    return handleOAuthLogin(config, 'github', 'GitHub', generateGitHubAuthUrl)
   }
   if (pathname === '/auth/callback/github' || pathname === '/auth/github/callback') {
     return handleOAuthCallbackRequest(request, config, 'github', handleGitHubCallback)
@@ -199,7 +216,7 @@ export async function handleOAuthRequest(
 
   // Google
   if (pathname === '/auth/oauth/google' || pathname === '/auth/google/login') {
-    return handleOAuthLogin(config, 'Google', generateGoogleAuthUrl)
+    return handleOAuthLogin(config, 'google', 'Google', generateGoogleAuthUrl)
   }
   if (pathname === '/auth/callback/google' || pathname === '/auth/google/callback') {
     return handleOAuthCallbackRequest(request, config, 'google', (c, code, s, r, v) => handleGoogleCallback(c, code, s, r, v!))
@@ -207,7 +224,7 @@ export async function handleOAuthRequest(
 
   // Discord
   if (pathname === '/auth/oauth/discord' || pathname === '/auth/discord/login') {
-    return handleOAuthLogin(config, 'Discord', generateDiscordAuthUrl)
+    return handleOAuthLogin(config, 'discord', 'Discord', generateDiscordAuthUrl)
   }
   if (pathname === '/auth/callback/discord' || pathname === '/auth/discord/callback') {
     return handleOAuthCallbackRequest(request, config, 'discord', handleDiscordCallback)
@@ -215,7 +232,7 @@ export async function handleOAuthRequest(
 
   // Apple
   if (pathname === '/auth/oauth/apple' || pathname === '/auth/apple/login') {
-    return handleOAuthLogin(config, 'Apple', generateAppleAuthUrl)
+    return handleOAuthLogin(config, 'apple', 'Apple', generateAppleAuthUrl)
   }
   if (pathname === '/auth/callback/apple' || pathname === '/auth/apple/callback') {
     return handleOAuthCallbackRequest(request, config, 'apple', handleAppleCallback)
@@ -223,7 +240,7 @@ export async function handleOAuthRequest(
 
   // Microsoft
   if (pathname === '/auth/oauth/microsoft' || pathname === '/auth/microsoft/login') {
-    return handleOAuthLogin(config, 'Microsoft', generateMicrosoftAuthUrl)
+    return handleOAuthLogin(config, 'microsoft', 'Microsoft', generateMicrosoftAuthUrl)
   }
   if (pathname === '/auth/callback/microsoft' || pathname === '/auth/microsoft/callback') {
     return handleOAuthCallbackRequest(request, config, 'microsoft', (c, code, s, r, v) => handleMicrosoftCallback(c, code, s, r, v!))
@@ -231,7 +248,7 @@ export async function handleOAuthRequest(
 
   // LinkedIn
   if (pathname === '/auth/oauth/linkedin' || pathname === '/auth/linkedin/login') {
-    return handleOAuthLogin(config, 'LinkedIn', generateLinkedInAuthUrl)
+    return handleOAuthLogin(config, 'linkedin', 'LinkedIn', generateLinkedInAuthUrl)
   }
   if (pathname === '/auth/callback/linkedin' || pathname === '/auth/linkedin/callback') {
     return handleOAuthCallbackRequest(request, config, 'linkedin', handleLinkedInCallback)
@@ -239,13 +256,19 @@ export async function handleOAuthRequest(
 
   // Meta
   if (pathname === '/auth/oauth/meta' || pathname === '/auth/meta/login') {
-    return handleOAuthLogin(config, 'Meta', generateMetaAuthUrl)
+    return handleOAuthLogin(config, 'meta', 'Meta', generateMetaAuthUrl)
   }
   if (pathname === '/auth/callback/meta' || pathname === '/auth/meta/callback') {
     return handleOAuthCallbackRequest(request, config, 'meta', handleMetaCallback)
   }
 
   return new Response('Not Found', { status: 404 })
+}
+
+function getRedirectUri(config: ClearAuthConfig, providerKey: string): string {
+  const provider = config.oauth?.[providerKey as keyof NonNullable<ClearAuthConfig['oauth']>]
+  if (!provider) throw new Error(`OAuth provider ${providerKey} is not configured`)
+  return provider.redirectUri
 }
 
 /**

--- a/src/oauth/handler.ts
+++ b/src/oauth/handler.ts
@@ -109,7 +109,7 @@ async function handleOAuthCallbackRequest(
     const error = url.searchParams.get('error')
 
     if (error) {
-      return new Response(`OAuth error: ${error}`, { status: 400 })
+      return new Response('OAuth authorization was denied', { status: 400 })
     }
 
     if (!code || !returnedState) {

--- a/src/oauth/transactions.ts
+++ b/src/oauth/transactions.ts
@@ -1,14 +1,17 @@
 import type { Kysely } from 'kysely'
 import type { Database, NewOAuthTransaction, OAuthTransaction } from '../database/schema.js'
 
-const TRANSACTION_TTL_MS = 10 * 60 * 1000
+export const OAUTH_TRANSACTION_TTL_SECONDS = 10 * 60
+const TRANSACTION_TTL_MS = OAUTH_TRANSACTION_TTL_SECONDS * 1000
 const TRANSACTION_ID_PATTERN = /^[A-Za-z0-9_-]{20,}$/
 
 export interface OAuthCallbackEvidence {
   returnedState: string
   providerKey: string
   redirectUri: string
+  /** Reserved for external adapters in Phase 3; conventional providers use no issuer binding. */
   returnedIssuer?: string
+  /** Reserved for external adapters in Phase 3; conventional providers use no adapter metadata. */
   adapterMetadata?: string
   browserBindingSecret: string
   now: Date

--- a/src/oauth/transactions.ts
+++ b/src/oauth/transactions.ts
@@ -105,18 +105,27 @@ export function createOAuthTransactionStore(db: Kysely<Database>): OAuthTransact
 
     async validateAndConsume(id, evidence) {
       // This conditional update is the sole validation/consumption operation. It is safe under concurrent callbacks.
-      const transaction = await db
+      let query = db
         .updateTable('oauth_transactions')
         .set({ consumed_at: evidence.now })
         .where('id', '=', id)
         .where('state_hash', '=', await sha256(evidence.returnedState))
         .where('provider_key', '=', evidence.providerKey)
         .where('redirect_uri', '=', evidence.redirectUri)
-        .where('expected_issuer', 'is', evidence.returnedIssuer ?? null)
-        .where('adapter_metadata_hash', 'is', evidence.adapterMetadata ? await sha256(evidence.adapterMetadata) : null)
         .where('browser_binding_hash', '=', await sha256(evidence.browserBindingSecret))
         .where('expires_at', '>', evidence.now)
         .where('consumed_at', 'is', null)
+
+      query = evidence.returnedIssuer === undefined
+        ? query.where('expected_issuer', 'is', null)
+        : query.where('expected_issuer', '=', evidence.returnedIssuer)
+
+      const metadataHash = evidence.adapterMetadata ? await sha256(evidence.adapterMetadata) : null
+      query = metadataHash === null
+        ? query.where('adapter_metadata_hash', 'is', null)
+        : query.where('adapter_metadata_hash', '=', metadataHash)
+
+      const transaction = await query
         .returningAll()
         .executeTakeFirst()
       return transaction ?? null

--- a/src/oauth/transactions.ts
+++ b/src/oauth/transactions.ts
@@ -9,6 +9,7 @@ export interface OAuthCallbackEvidence {
   providerKey: string
   redirectUri: string
   returnedIssuer?: string
+  adapterMetadata?: string
   browserBindingSecret: string
   now: Date
 }
@@ -69,7 +70,7 @@ export async function createOAuthTransaction(input: CreateOAuthTransactionInput)
       code_verifier: input.codeVerifier ?? null,
       redirect_uri: input.redirectUri,
       expected_issuer: input.expectedIssuer ?? null,
-      adapter_metadata: input.adapterMetadata ?? null,
+      adapter_metadata_hash: input.adapterMetadata ? await sha256(input.adapterMetadata) : null,
       browser_binding_hash: await sha256(browserBindingSecret),
       expires_at: expiresAt,
       consumed_at: null,
@@ -109,6 +110,7 @@ export function createOAuthTransactionStore(db: Kysely<Database>): OAuthTransact
         .where('provider_key', '=', evidence.providerKey)
         .where('redirect_uri', '=', evidence.redirectUri)
         .where('expected_issuer', 'is', evidence.returnedIssuer ?? null)
+        .where('adapter_metadata_hash', 'is', evidence.adapterMetadata ? await sha256(evidence.adapterMetadata) : null)
         .where('browser_binding_hash', '=', await sha256(evidence.browserBindingSecret))
         .where('expires_at', '>', evidence.now)
         .where('consumed_at', 'is', null)

--- a/src/oauth/transactions.ts
+++ b/src/oauth/transactions.ts
@@ -1,0 +1,125 @@
+import type { Kysely } from 'kysely'
+import type { Database, NewOAuthTransaction, OAuthTransaction } from '../database/schema.js'
+
+const TRANSACTION_TTL_MS = 10 * 60 * 1000
+const TRANSACTION_ID_PATTERN = /^[A-Za-z0-9_-]{20,}$/
+
+export interface OAuthCallbackEvidence {
+  returnedState: string
+  providerKey: string
+  redirectUri: string
+  returnedIssuer?: string
+  browserBindingSecret: string
+  now: Date
+}
+
+export interface OAuthTransactionStore {
+  create(transaction: NewOAuthTransaction): Promise<OAuthTransaction>
+  validateAndConsume(id: string, evidence: OAuthCallbackEvidence): Promise<OAuthTransaction | null>
+  cleanupExpired(now?: Date): Promise<number>
+}
+
+export interface CreateOAuthTransactionInput {
+  providerKey: string
+  redirectUri: string
+  codeVerifier?: string
+  expectedIssuer?: string
+  adapterMetadata?: string
+  expiresAt?: Date
+}
+
+export interface PreparedOAuthTransaction {
+  id: string
+  state: string
+  browserBindingSecret: string
+  codeVerifier?: string
+  transaction: NewOAuthTransaction
+}
+
+function randomBase64Url(bytes: number): string {
+  const value = new Uint8Array(bytes)
+  crypto.getRandomValues(value)
+  let binary = ''
+  for (const byte of value) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+async function sha256(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+/** Create server-side transaction material. Never expose the verifier or binding secret in a response body. */
+export async function createOAuthTransaction(input: CreateOAuthTransactionInput): Promise<PreparedOAuthTransaction> {
+  const id = randomBase64Url(24)
+  const state = `${id}.${randomBase64Url(32)}`
+  const browserBindingSecret = randomBase64Url(32)
+  const expiresAt = input.expiresAt ?? new Date(Date.now() + TRANSACTION_TTL_MS)
+
+  return {
+    id,
+    state,
+    browserBindingSecret,
+    codeVerifier: input.codeVerifier,
+    transaction: {
+      id,
+      provider_key: input.providerKey,
+      state_hash: await sha256(state),
+      code_verifier: input.codeVerifier ?? null,
+      redirect_uri: input.redirectUri,
+      expected_issuer: input.expectedIssuer ?? null,
+      adapter_metadata: input.adapterMetadata ?? null,
+      browser_binding_hash: await sha256(browserBindingSecret),
+      expires_at: expiresAt,
+      consumed_at: null,
+    },
+  }
+}
+
+/** State deliberately includes the opaque transaction ID so the callback can locate its binding cookie. */
+export function parseOAuthTransactionState(state: string): { id: string; state: string } | null {
+  const [id, secret, ...rest] = state.split('.')
+  if (rest.length > 0 || !id || !secret || !TRANSACTION_ID_PATTERN.test(id) || !TRANSACTION_ID_PATTERN.test(secret)) {
+    return null
+  }
+  return { id, state }
+}
+
+export function getOAuthTransactionCookieName(providerKey: string, transactionId: string): string {
+  if (!/^[a-z0-9_-]+$/.test(providerKey) || !TRANSACTION_ID_PATTERN.test(transactionId)) {
+    throw new Error('Invalid OAuth transaction cookie reference')
+  }
+  return `oauth_tx_${providerKey}_${transactionId}`
+}
+
+export function createOAuthTransactionStore(db: Kysely<Database>): OAuthTransactionStore {
+  return {
+    async create(transaction) {
+      return db.insertInto('oauth_transactions').values(transaction).returningAll().executeTakeFirstOrThrow()
+    },
+
+    async validateAndConsume(id, evidence) {
+      // This conditional update is the sole validation/consumption operation. It is safe under concurrent callbacks.
+      const transaction = await db
+        .updateTable('oauth_transactions')
+        .set({ consumed_at: evidence.now })
+        .where('id', '=', id)
+        .where('state_hash', '=', await sha256(evidence.returnedState))
+        .where('provider_key', '=', evidence.providerKey)
+        .where('redirect_uri', '=', evidence.redirectUri)
+        .where('expected_issuer', 'is', evidence.returnedIssuer ?? null)
+        .where('browser_binding_hash', '=', await sha256(evidence.browserBindingSecret))
+        .where('expires_at', '>', evidence.now)
+        .where('consumed_at', 'is', null)
+        .returningAll()
+        .executeTakeFirst()
+      return transaction ?? null
+    },
+
+    async cleanupExpired(now = new Date()) {
+      const result = await db.deleteFrom('oauth_transactions').where('expires_at', '<=', now).executeTakeFirst()
+      return Number(result.numDeletedRows ?? 0)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- add server-side one-time OAuth transactions with atomic consume validation
- replace shared OAuth state and PKCE cookies with provider-and-transaction scoped browser-binding cookies
- add migration and deployment guidance, including a forward migration for early preview schemas

## Context

Implements PRD 0005 Phase 1 only. Phase 2 generic accounts and outcome-aware resolution remain intentionally separate.

## Validation

- dialectical player/coach review: approved after one revision
- bun run build
- bun run test: 49 files, 569 tests
- Semgrep: 0 findings
- roborev: clean
- security audit: no change-introduced findings; existing npm audit dependency debt recorded separately
- smoke: PASS via OAuth handler integration tests; this library has no self-hosted server surface

## Migration

Apply migrations 009 and 010 before deploying. See docs/OAUTH_TRANSACTION_DEPLOYMENT.md for the fail-closed transition behavior.