### PR TITLE
fix(storage): preserve canonical Mech app IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-16
+
+### Fixed
+
+- **Mech Storage canonical app IDs** — Preserve `app_<uuid>` in PostgreSQL API
+  request paths so the URL identity matches the identity bound to `X-API-Key`.
+  This restores login and session queries after Mech Storage authentication
+  tightening. (Codex, 2026-08-16)
+
 ### Added
 
 - **Transaction-bound OAuth callbacks** (Codex, 2026-07-15)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clearauth",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "ClearAuth: lightweight authentication library with Arctic OAuth, pluggable password hashing, and Kysely-backed storage",
   "keywords": [
     "clearauth",

--- a/src/__tests__/mech-sql-client.test.ts
+++ b/src/__tests__/mech-sql-client.test.ts
@@ -102,7 +102,7 @@ describe("MechSqlClient", () => {
       expect(headers["X-App-ID"]).toBeUndefined()
     })
 
-    it("should strip app_ prefix from appId in URL path", async () => {
+    it("should preserve app_ prefix from appId in URL path", async () => {
       global.fetch = vi.fn().mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -122,9 +122,7 @@ describe("MechSqlClient", () => {
 
       const fetchCall = (global.fetch as any).mock.calls[0]
       const url = fetchCall[0] as string
-      // URL should use the raw UUID, not app_UUID
-      expect(url).toContain(`/api/apps/${validUuid}/`)
-      expect(url).not.toContain("app_")
+      expect(url).toBe(`https://storage.mechdna.net/api/apps/app_${validUuid}/postgresql/query`)
     })
 
     it("should handle empty result set", async () => {

--- a/src/mech-sql-client.ts
+++ b/src/mech-sql-client.ts
@@ -153,9 +153,7 @@ export class MechSqlClient {
   }
 
   private async executeOnce<R = unknown>(sql: string, params: readonly unknown[]): Promise<{ rows: R[]; rowCount: number }> {
-    // Strip "app_" prefix if present — URL path wants the raw UUID only
-    const pathAppId = this.appId.replace(/^app_/, "")
-    const url = `${this.baseUrl.replace(/\/$/, "")}/api/apps/${pathAppId}/postgresql/query`
+    const url = `${this.baseUrl.replace(/\/$/, "")}/api/apps/${this.appId}/postgresql/query`
 
     this.logger.debug("Executing SQL query", {
       url,

--- a/tasks/0006-canonical-mech-storage-app-id-release.md
+++ b/tasks/0006-canonical-mech-storage-app-id-release.md
@@ -1,0 +1,20 @@
+# Canonical Mech Storage app ID release
+
+## Source
+
+- User instruction: publish the ClearAuth login fix through the standard development workflow.
+- Incident report: `msg-1786899338000-mechbrowse` from mech-browse.
+
+## Problem
+
+Mech Storage now verifies that the app ID in a PostgreSQL request URL exactly
+matches the identity bound to `X-API-Key`. ClearAuth removed the `app_` prefix
+from canonical application IDs, causing authenticated login queries to fail.
+
+## Acceptance criteria
+
+1. `MechSqlClient` preserves `app_<uuid>` in `/api/apps/{appId}/postgresql/query`.
+2. Regression coverage asserts the canonical URL path.
+3. The focused client test, full suite, build, and live read-only session soak pass.
+4. The change passes adversarial and pre-push review before push.
+5. A reviewed PR is merged before publishing `clearauth@0.7.3` to npmjs.


### PR DESCRIPTION
## Planning authority
- Task: tasks/0006-canonical-mech-storage-app-id-release.md
- Incident: msg-1786899338000-mechbrowse

## Change
Preserves canonical app_<uuid> values in Mech Storage PostgreSQL request URLs so the URL identity matches the API-key-bound app identity. Prepares npm release 0.7.3.

## Validation
- npm test: 580 passed
- bun run build: passed
- npm pack --dry-run: passed
- Semgrep: 0 findings
- false-green scan: 0 candidates
- Roborev complete range review: clean (job 21810)
- Live read-only session soak: 40/40 HTTP 200; p95 231.2 ms

Smoke: PASS:command:live read-only ClearAuth session soak (40/40 HTTP 200)
Soak: PASS:command:40 sequential live session requests; p95 231.2 ms

## Release
Publish clearauth@0.7.3 to npmjs only after this security-sensitive PR has an explicit approval and is merged.