### PR TITLE
fix(storage): normalize bare Mech app IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Mech Storage canonical app IDs** — Preserve `app_<uuid>` in PostgreSQL API
-  request paths so the URL identity matches the identity bound to `X-API-Key`.
-  This restores login and session queries after Mech Storage authentication
-  tightening. (Codex, 2026-08-16)
+- **Mech Storage canonical app IDs** — Normalize a bare UUID to `app_<uuid>` and
+  preserve canonical IDs in PostgreSQL API request paths so the URL identity
+  matches the identity bound to `X-API-Key`. This restores login and session
+  queries after Mech Storage authentication tightening. (Codex, 2026-08-16)
 
 ### Added
 

--- a/src/__tests__/integration-auth-flow.test.ts
+++ b/src/__tests__/integration-auth-flow.test.ts
@@ -34,7 +34,7 @@ describe("Integration: Auth Flow (Register -> Login -> Session -> Logout)", () =
     const userId = "user-uuid-123"
     const sessionId = "session-random-id-123"
 
-    const expectedMechUrl = `https://storage.mechdna.net/api/apps/${TEST_APP_ID}/postgresql/query`
+    const expectedMechUrl = `https://storage.mechdna.net/api/apps/app_${TEST_APP_ID}/postgresql/query`
 
     // 1. Mock Registration
     // - Check if user exists (none)

--- a/src/__tests__/jwt-integration.test.ts
+++ b/src/__tests__/jwt-integration.test.ts
@@ -15,7 +15,6 @@ import * as arcticProviders from "../oauth/arctic-providers.js"
 const TEST_APP_ID = "550e8400-e29b-41d4-a716-446655440001"
 const TEST_API_KEY = "test-api-key-jwt"
 const TEST_SECRET = "test-secret-key-at-least-32-chars-long"
-const expectedMechUrl = `https://storage.mechdna.net/api/apps/${TEST_APP_ID}/postgresql/query`
 
 const hasher = createPbkdf2PasswordHasher()
 

--- a/src/__tests__/mech-sql-client.test.ts
+++ b/src/__tests__/mech-sql-client.test.ts
@@ -102,7 +102,26 @@ describe("MechSqlClient", () => {
       expect(headers["X-App-ID"]).toBeUndefined()
     })
 
-    it("should preserve app_ prefix from appId in URL path", async () => {
+    it("should normalize a bare UUID appId to the canonical app_ URL path", async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          rows: [],
+          rowCount: 0
+        })
+      })
+
+      const client = new MechSqlClient(baseConfig)
+      await client.execute("SELECT 1")
+
+      const fetchCall = (global.fetch as any).mock.calls[0]
+      const url = fetchCall[0] as string
+      expect(url).toBe(`https://storage.mechdna.net/api/apps/app_${validUuid}/postgresql/query`)
+    })
+
+    it("should preserve an already canonical app_ appId in the URL path", async () => {
       global.fetch = vi.fn().mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -123,6 +142,7 @@ describe("MechSqlClient", () => {
       const fetchCall = (global.fetch as any).mock.calls[0]
       const url = fetchCall[0] as string
       expect(url).toBe(`https://storage.mechdna.net/api/apps/app_${validUuid}/postgresql/query`)
+      expect(url).not.toContain(`app_app_${validUuid}`)
     })
 
     it("should handle empty result set", async () => {

--- a/src/__tests__/mech-sql-client.test.ts
+++ b/src/__tests__/mech-sql-client.test.ts
@@ -145,6 +145,25 @@ describe("MechSqlClient", () => {
       expect(url).not.toContain(`app_app_${validUuid}`)
     })
 
+    it("should canonicalize an uppercase app_ prefix without double-prefixing", async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          rows: [],
+          rowCount: 0
+        })
+      })
+
+      const client = new MechSqlClient({ ...baseConfig, appId: `APP_${validUuid}` })
+      await client.execute("SELECT 1")
+
+      const url = (global.fetch as any).mock.calls[0][0] as string
+      expect(url).toBe(`https://storage.mechdna.net/api/apps/app_${validUuid}/postgresql/query`)
+      expect(url).not.toContain(`app_APP_${validUuid}`)
+    })
+
     it("should handle empty result set", async () => {
       global.fetch = vi.fn().mockResolvedValueOnce({
         ok: true,

--- a/src/mech-sql-client.ts
+++ b/src/mech-sql-client.ts
@@ -153,7 +153,8 @@ export class MechSqlClient {
   }
 
   private async executeOnce<R = unknown>(sql: string, params: readonly unknown[]): Promise<{ rows: R[]; rowCount: number }> {
-    const url = `${this.baseUrl.replace(/\/$/, "")}/api/apps/${this.appId}/postgresql/query`
+    const canonicalAppId = this.appId.startsWith("app_") ? this.appId : `app_${this.appId}`
+    const url = `${this.baseUrl.replace(/\/$/, "")}/api/apps/${canonicalAppId}/postgresql/query`
 
     this.logger.debug("Executing SQL query", {
       url,

--- a/src/mech-sql-client.ts
+++ b/src/mech-sql-client.ts
@@ -153,7 +153,9 @@ export class MechSqlClient {
   }
 
   private async executeOnce<R = unknown>(sql: string, params: readonly unknown[]): Promise<{ rows: R[]; rowCount: number }> {
-    const canonicalAppId = this.appId.startsWith("app_") ? this.appId : `app_${this.appId}`
+    const canonicalAppId = /^app_/i.test(this.appId)
+      ? `app_${this.appId.slice(4)}`
+      : `app_${this.appId}`
     const url = `${this.baseUrl.replace(/\/$/, "")}/api/apps/${canonicalAppId}/postgresql/query`
 
     this.logger.debug("Executing SQL query", {

--- a/tasks/0007-normalize-mech-storage-app-id.md
+++ b/tasks/0007-normalize-mech-storage-app-id.md
@@ -1,0 +1,20 @@
+# Normalize Mech Storage app IDs at the client boundary
+
+## Source
+
+- User direction to continue the ClearAuth login release through the standard development workflow.
+- PR #39 review feedback: preserving an existing `app_` prefix does not make the documented bare UUID configuration work.
+- Live direct SQL verification: canonical `app_<uuid>` succeeds while the matching bare UUID receives HTTP 401.
+
+## Problem
+
+Mech Storage requires an `app_<uuid>` identity in the PostgreSQL API URL. ClearAuth accepts both a bare UUID and canonical app ID, but currently sends a bare UUID unchanged. This leaves the documented/default bare UUID configuration unable to authenticate.
+
+## Acceptance criteria
+
+1. A bare UUID app ID is normalized to `app_<uuid>` only for the Mech Storage request URL.
+2. An already canonical `app_<uuid>` remains unchanged; no double prefix is introduced.
+3. Schema-ID behavior remains unchanged so existing database schemas are addressed consistently.
+4. Direct unit coverage proves both accepted configuration forms produce the same canonical URL.
+5. Full tests, build, security/review gates, and a read-only live alternating canonical/bare-ID SQL soak pass before PR submission.
+6. The unpublished `clearauth@0.7.3` release candidate contains this correction before it is published.


### PR DESCRIPTION
## Summary

- normalize bare UUID app IDs to canonical app_<uuid> only in Mech Storage request URLs
- preserve already canonical app IDs without double-prefixing
- align unit and auth-flow integration assertions with the canonical API contract

## Verification

- npm test (581 passed)
- npm run build
- npm pack --dry-run
- Semgrep: 0 findings
- false-green scan: passed
- Roborev job 21820: no issues found
- Live read-only SQL soak: 40/40 alternating bare/canonical configuration requests passed; p95 252.3 ms

The package remains the unpublished clearauth@0.7.3 release candidate.